### PR TITLE
Slight refactor

### DIFF
--- a/Marathon.IO/Formats/FormatList.txt
+++ b/Marathon.IO/Formats/FormatList.txt
@@ -1,0 +1,44 @@
+﻿.arc	-	Compressed U8 Archive								-	Full Support (U8Archive.cs)
+.bin	-	Various Generic Binary Archives						-	N/A
+.csb	-	Cue Sheet Binary									-	No Support
+.ddm	-	DirectDraw Matrix									-	Partial Support (DirectDrawMatrix.cs)
+.dds	-	DirectDraw Surface Texture							-	No Support
+.epb	-	Event Playbook										-	Full Support (EventPlaybook.cs)
+.fpo	-	???													-	N/A
+.ftm	-	Font Map Table										-	Little Support (FontMap.cs)
+.fxo	-	Shader												-	No Support
+.hkx	-	Havok 3.3.0-b2 Binary								-	No Support
+.kbf	-	Autodesk Kynapse									-	No Support
+.lub	-	Lua Bytecode										-	Little Support (non functional Lua Decompiler)
+.mab	-	Particle ???										-	No Support
+.mbi	-	Motion Base Information								-	Plain Text
+.mdl	-	SOX Model											-	Partial Support (SOXModel.cs)
+.mst	-	Message Table										-	Full Support (MessageTable.cs)
+.path	-	Path Spline											-	Partial Support (PathSpline.cs)
+.peb	-	Particle Effect Bank								-	No Support
+.pfi	-	Picture Font Information?							-	No Support
+.pft	-	Picture Font Table									-	Full Support (PictureFont.cs)
+.pgs	-	Particle Generation System?							-	No Support
+.pkg	-	Asset Package										-	Full Support (AssetPackage.cs)
+.plc	-	Particle List Container?							-	Full(?) Support (ParticleListContainer.cs)
+.png	-	Portable Network Graphic							-	No Support, can be handled in NET Framework.
+.prop	-	Object Property Database?							-	Full Support (ObjectPropertyDatabase.cs)
+.ptb	-	Particle Texture Bank?								-	Full(?) Support (ParticleTextureBank.cs)
+.rab	-	Reflection Zone										-	Full(?) Support (ReflectionZone.cs)
+.sbk	-	Scene Bank											-	Full Support (SceneBank.cs)
+.set	-	Object Placement, Stage Entity Table?				-	Full Support (ObjectPlacement.cs)
+.tev	-	Time Event											-	Partial Support (TimeEvent.cs)
+.vpo	-	???													-	N/A
+.xna	-	Unknown SegaNN Format								-	No Support
+.xncp	-	Xbox Ninja UI										-	No Support
+.xnd	-	Unknown SegaNN Format seemingly related to cameras	-	No Support
+.xne	-	Unknown SegaNN Format (Xbox Ninja Effect?)			-	No Support
+.xnf	-	Xbox Ninja Morph Motion								-	No Support
+.xng	-	Unknown SegaNN Format								-	No Support
+.xni	-	Xbox Ninja Illumination?							-	No Support
+.xnm	-	Xbox Ninja Motion									-	Little Support (SegaNNXbox.cs)
+.xno	-	Xbox Ninja Object									-	Little Support (SegaNNXbox.cs)
+.xnv	-	Xbox Ninja Material Colour							-	Little Support (SegaNNXbox.cs)
+.xtm	-	Plain Text Xbox Ninja Motion						-	Plain Text
+.xto	-	Plain Text Xbox Ninja Object						-	Plain Text
+.xtv	-	Plain Text Xbox Ninja Material Colour				-	Plain Text

--- a/Marathon.IO/Formats/Meshes/Collision.cs
+++ b/Marathon.IO/Formats/Meshes/Collision.cs
@@ -37,6 +37,19 @@ namespace Marathon.IO.Formats.Meshes
     /// </summary>
     public class Collision : FileBase
     {
+        public Collision(string file)
+        {
+            switch (Path.GetExtension(file))
+            {
+                case ".obj":
+                    ImportOBJ(file);
+                    break;
+                default:
+                    Load(file);
+                    break;
+            }
+        }
+
         public class Face
         {
             public ushort Vertex1, Vertex2, Vertex3;
@@ -73,9 +86,9 @@ namespace Marathon.IO.Formats.Meshes
                     Vertex3 = reader.ReadUInt16()
                 };
 
-                reader.JumpAhead(2);
+                reader.JumpAhead(2); // Could probably use reader.FixPadding(); here?
 
-                face.Flags = reader.ReadUInt32();
+                face.Flags = reader.ReadUInt32(); // Could probably do with finding a way to read each Nibble (half byte) individually.
 
                 Faces.Add(face);
             }
@@ -109,7 +122,7 @@ namespace Marathon.IO.Formats.Meshes
                 writer.Write(Faces[i].Vertex1);
                 writer.Write(Faces[i].Vertex2);
                 writer.Write(Faces[i].Vertex3);
-                writer.WriteNulls(2);
+                writer.WriteNulls(2);           // Could probably use writer.FixPadding(); here?
                 writer.Write(Faces[i].Flags);
             }
 

--- a/Marathon.IO/Formats/Meshes/Collision.cs
+++ b/Marathon.IO/Formats/Meshes/Collision.cs
@@ -39,6 +39,7 @@ namespace Marathon.IO.Formats.Meshes
     /// </summary>
     public class Collision : FileBase
     {
+        public Collision() { }
         public Collision(string file)
         {
             switch (Path.GetExtension(file))

--- a/Marathon.IO/Formats/Meshes/ReflectionZone.cs
+++ b/Marathon.IO/Formats/Meshes/ReflectionZone.cs
@@ -38,6 +38,8 @@ namespace Marathon.IO.Formats.Meshes
     public class ReflectionZone : FileBase
     {
         // TODO: Comment code and test on more than one file
+
+        public ReflectionZone() { }
         public ReflectionZone(string file)
         {
             switch (Path.GetExtension(file))

--- a/Marathon.IO/Formats/Meshes/ReflectionZone.cs
+++ b/Marathon.IO/Formats/Meshes/ReflectionZone.cs
@@ -38,6 +38,18 @@ namespace Marathon.IO.Formats.Meshes
     public class ReflectionZone : FileBase
     {
         // TODO: Comment code and test on more than one file
+        public ReflectionZone(string file)
+        {
+            switch (Path.GetExtension(file))
+            {
+                case ".xml":
+                    ImportXML(file);
+                    break;
+                default:
+                    Load(file);
+                    break;
+            }
+        }
 
         public class Reflection
         {

--- a/Marathon.IO/Formats/Meshes/SOXModel.cs
+++ b/Marathon.IO/Formats/Meshes/SOXModel.cs
@@ -1,0 +1,621 @@
+﻿using System;
+using System.IO;
+using System.Collections.Generic;
+using Marathon.IO.Exceptions;
+using Assimp;
+
+namespace Marathon.IO.Formats.Meshes
+{
+    /// <summary>
+    /// <para>File base for the MDL format.</para>
+    /// <para>Used for various stage models in the PS3 version of SONIC THE HEDGEHOG.</para>
+    /// </summary>
+
+    //TODO: Clean up this garbage code and understand all the Unknown Values.
+    public class SOXModel : FileBase
+    {
+        public SOXModel() { }
+        public SOXModel(string file)
+        {
+            switch (Path.GetExtension(file))
+            {
+                case ".fbx":
+                case ".obj":
+                    //ImportAssimp(file); Need to get rid of the need for a donor model to make this work.
+                    break;
+                default:
+                    Load(file);
+                    break;
+            }
+        }
+
+        public class AABB
+        {
+            public Vector3 Minimum;
+            public Vector3 Maximum;
+        }
+        public class RGBA
+        {
+            public byte Red;
+            public byte Green;
+            public byte Blue;
+            public byte Alpha;
+        }
+
+        public class Vertex
+        {
+            public Vector3 Position;
+            public uint UnknownUInt32_1;           // Something to do with base shadow? Number seems almost random.
+            public uint UnknownUInt32_2;           // Setting this to 0 seemingly made every vertex cast a shadow? Number seems almost random.
+            public RGBA VertexColour = new RGBA(); // 4 bytes making up a set of RGBA values
+            public Half XTextureCoordinate;
+            public Half YTextureCoordinate;
+            public uint UnknownUInt32_3;           // Something to do with distant shadows? Number seems almost random.
+        }
+
+        public class Face
+        {
+            public ushort Vertex1;
+            public ushort Vertex2;
+            public ushort Vertex3;
+        }
+
+        public class Texture
+        {
+            public string Name;
+            public uint UnknownUInt32_1; // Always 2 in official files.
+            public uint UnknownUInt32_2; // Always 0 in official files.
+            public uint UnknownUInt32_3; // Always 0 in official files.
+            public uint UnknownUInt32_4; // Always 1 in official files.
+            public uint TextureID; // 0 - 81? Think this might be Texture ID based on patterns.
+            public uint TextureType; // Either 0, 1 or 2 in official files. 0 might be Punch Transparency, 1 might be Light Map Stuff? 2 seems to be standard?
+        }
+
+        public class Material
+        {
+            public string Name;
+            public uint UnknownUInt32_1;  // Always 0 in official files (padding or part of the name?)
+            public string EffectFile;
+            public uint UnknownUInt32_2;  // Used values: 0, 1, 2, 3, 5, 9, 12, 14, 15, 18
+            public string EffectTechnique;
+            public uint UnknownUInt32_3;  // Always 0 in official files (padding or part of the technique?)
+            public float UnknownFloat_1;  // Holds a value between 0 and 1.
+            public float UnknownFloat_2;  // Holds a value between 0 and 1.
+            public float UnknownFloat_3;  // Holds a value between 0 and 1.
+            public float UnknownFloat_4;  // Always 1 in official files.
+            public float UnknownFloat_5;  // Holds a value between 0 and 1.
+            public float UnknownFloat_6;  // Holds a value between 0 and 1.
+            public float UnknownFloat_7;  // Holds a value between 0 and 1.
+            public float UnknownFloat_8;  // Holds a value between 0 and 1.
+            public float UnknownFloat_9;  // Holds a value between 0 and 1.
+            public float UnknownFloat_10; // Holds a value between 0 and 1.
+            public float UnknownFloat_11; // Holds a value between 0 and 1.
+            public float UnknownFloat_12; // Always 1 in official files.
+            public float UnknownFloat_13; // Either 0, 0.2941177 or 1 in official files.
+            public float UnknownFloat_14; // Holds a value between 0 and 1.
+            public float UnknownFloat_15; // Always 0 in official files.
+            public float UnknownFloat_16; // Always 1 in official files.
+            public float UnknownFloat_17; // Various different values up to 4096: 0, 4, 4.287094, 4.924578, 8, 8, 11.31371, 12.12573, 16, 22.62742, 32, 63.99999, 68.5935, 90.50966, 128, 512, 2896.309, 4096
+            public string TextureFile1;
+            public uint UnknownUInt32_4;  // 0 - 19? But doesn't have 17?
+            public string TextureFile2;
+            public uint UnknownUInt32_5;  // 0 - 16? But doesn't have 9 or 11?
+            public string TextureFile3;
+            public uint UnknownUInt32_6;  // Always 0 in official files (padding or part of the name?)
+            public string TextureFile4;
+            public uint UnknownUInt32_7;  // Always 0 in official files (padding or part of the name?)
+            public uint UnknownUInt32_8;  // Either 0, 1 or 4 in official files.
+            public uint UnknownUInt32_9;  // Either 0 or 1 in official files (some form of bool instead?) Might be for semi transparency? Just based on the materials that use this at 1?
+            public uint BackfaceCull;     // Whether the backs of faces using this model should be culled out.
+            public uint UnknownUInt32_11; // Either 0 or 16777216 in official files (maybe actually a bool in a single byte?)
+            public uint UnknownUInt32_12; // Either 0 or 128 in official files.
+            public uint UnknownUInt32_13; // Either 4 or 7 in official files.
+            public uint UnknownUInt32_14; // Either 0 or 3 in official files.
+            public float UnknownFloat_18; // 0, 1.742946E-39, 1.834782E-39, 1 or 2 in official files.
+        }
+
+        public class Mesh
+        {
+            public string Material;
+            public uint UnknownUInt32_1;   // Always 3 in official files.
+            public uint UnknownUInt32_2;   // Unknown, number seems almost random.
+            public uint UnknownUInt32_3;   // Unknown, number seems almost random.
+            public uint FaceTablePosition; // This number divided by three seems to tell the game where to start reading within the Face Table.
+            public uint FaceCount;
+            public uint UnknownUInt32_4;   // Either 0, 1 or 2 in official files, something to do with Real Time Shadows, not sure why I made this note? Setting this to 2 did semi transparency.
+        }
+
+        public const string Signature = "SOX_MDL", Extension = ".mdl";
+
+        public AABB BoundingBox         = new AABB();
+        public List<uint> UnknownBytes  = new List<uint>(); // 784 bytes, not the same between all files, unsure what it does, reading them as uints right now.
+        public List<Vertex> Vertices    = new List<Vertex>();
+        public List<Face> Faces         = new List<Face>();
+        public List<Texture> Textures   = new List<Texture>();  
+        public List<Material> Materials = new List<Material>(); 
+        public List<Mesh> Meshes        = new List<Mesh>();     
+
+        public override void Load(Stream fileStream)
+        {
+            ExtendedBinaryReader reader = new ExtendedBinaryReader(fileStream, true);
+
+            // Signature Reading
+            string signature = reader.ReadSignature(7);
+            if (signature != Signature) throw new InvalidSignatureException(Signature, signature);
+            reader.JumpAhead(1); // Jump ahead by 1 to line up with multiples of 4.
+
+            // Header and Offsets
+            reader.JumpAhead(4);                        // Always 0x60 in official files.
+            reader.JumpAhead(4);                        // Always 0x20 in official files.
+            uint VerticesOffset  = reader.ReadUInt32(); // Always 0x360 in official files.
+            uint VerticiesCount  = reader.ReadUInt32(); // Needs dividng by 32 for my system.
+            uint FacesOffset     = reader.ReadUInt32();
+            uint FaceCount       = reader.ReadUInt32(); // Needs dividng by 3 for my system.
+            uint TexturesOffset  = reader.ReadUInt32();
+            uint TexturesCount   = reader.ReadUInt32();
+            uint MaterialsOffset = reader.ReadUInt32();
+            uint MaterialsCount  = reader.ReadUInt32();
+            uint MeshesOffset    = reader.ReadUInt32();
+            uint MeshCount       = reader.ReadUInt32();
+
+            // Bounding Box Vector3s.
+            BoundingBox.Minimum  = reader.ReadVector3();
+            BoundingBox.Maximum  = reader.ReadVector3();
+
+            // Not sure what these are. There's a lot of data here that is different between different files, nulling them causes the game to die.
+            while(reader.BaseStream.Position < 0x360) { UnknownBytes.Add(reader.ReadUInt32()); }
+
+            // Verticies
+            reader.JumpTo(VerticesOffset);
+            for(int i = 0; i < VerticiesCount / 32; i ++)
+            {
+                Vertex vertex             = new Vertex();
+                vertex.Position           = reader.ReadVector3();
+                vertex.UnknownUInt32_1    = reader.ReadUInt32();
+                vertex.UnknownUInt32_2    = reader.ReadUInt32();
+                vertex.VertexColour.Red   = reader.ReadByte();
+                vertex.VertexColour.Green = reader.ReadByte();
+                vertex.VertexColour.Blue  = reader.ReadByte();
+                vertex.VertexColour.Alpha = reader.ReadByte();
+                vertex.XTextureCoordinate = reader.ReadHalf();
+                vertex.YTextureCoordinate = reader.ReadHalf();
+                vertex.UnknownUInt32_3    = reader.ReadUInt32();
+                Vertices.Add(vertex);
+            }
+
+            // Faces
+            reader.JumpTo(FacesOffset);
+            for(int i = 0; i < FaceCount / 3; i++)
+            {
+                Face face = new Face
+                {
+                    Vertex1 = reader.ReadUInt16(),
+                    Vertex2 = reader.ReadUInt16(),
+                    Vertex3 = reader.ReadUInt16()
+                };
+                Faces.Add(face);
+            }
+
+            // Textures
+            reader.JumpTo(TexturesOffset);
+            for(int i = 0; i < TexturesCount; i++)
+            {
+                Texture texture = new Texture
+                {
+                    Name            = new string(reader.ReadChars(76)),
+                    UnknownUInt32_1 = reader.ReadUInt32(),
+                    UnknownUInt32_2 = reader.ReadUInt32(),
+                    UnknownUInt32_3 = reader.ReadUInt32(),
+                    UnknownUInt32_4 = reader.ReadUInt32(),
+                    TextureID = reader.ReadUInt32(),
+                    TextureType = reader.ReadUInt32()
+                };
+                Textures.Add(texture);
+            }
+
+            // Materials
+            reader.JumpTo(MaterialsOffset);
+            for (int i = 0; i < MaterialsCount; i++)
+            {
+                Material material = new Material
+                {
+                    Name             = new string(reader.ReadChars(60)),
+                    UnknownUInt32_1  = reader.ReadUInt32(),
+                    EffectFile       = new string(reader.ReadChars(60)),
+                    UnknownUInt32_2  = reader.ReadUInt32(),
+                    EffectTechnique  = new string(reader.ReadChars(60)),
+                    UnknownUInt32_3  = reader.ReadUInt32(),
+                    UnknownFloat_1   = reader.ReadSingle(),
+                    UnknownFloat_2   = reader.ReadSingle(),
+                    UnknownFloat_3   = reader.ReadSingle(),
+                    UnknownFloat_4   = reader.ReadSingle(),
+                    UnknownFloat_5   = reader.ReadSingle(),
+                    UnknownFloat_6   = reader.ReadSingle(),
+                    UnknownFloat_7   = reader.ReadSingle(),
+                    UnknownFloat_8   = reader.ReadSingle(),
+                    UnknownFloat_9   = reader.ReadSingle(),
+                    UnknownFloat_10  = reader.ReadSingle(),
+                    UnknownFloat_11  = reader.ReadSingle(),
+                    UnknownFloat_12  = reader.ReadSingle(),
+                    UnknownFloat_13  = reader.ReadSingle(),
+                    UnknownFloat_14  = reader.ReadSingle(),
+                    UnknownFloat_15  = reader.ReadSingle(),
+                    UnknownFloat_16  = reader.ReadSingle(),
+                    UnknownFloat_17  = reader.ReadSingle(),
+                    TextureFile1     = new string(reader.ReadChars(60)),
+                    UnknownUInt32_4  = reader.ReadUInt32(),
+                    TextureFile2     = new string(reader.ReadChars(60)),
+                    UnknownUInt32_5  = reader.ReadUInt32(),
+                    TextureFile3     = new string(reader.ReadChars(60)),
+                    UnknownUInt32_6  = reader.ReadUInt32(),
+                    TextureFile4     = new string(reader.ReadChars(60)),
+                    UnknownUInt32_7  = reader.ReadUInt32(),
+                    UnknownUInt32_8  = reader.ReadUInt32(),
+                    UnknownUInt32_9  = reader.ReadUInt32(),
+                    BackfaceCull = reader.ReadUInt32(),
+                    UnknownUInt32_11 = reader.ReadUInt32(),
+                    UnknownUInt32_12 = reader.ReadUInt32(),
+                    UnknownUInt32_13 = reader.ReadUInt32(),
+                    UnknownUInt32_14 = reader.ReadUInt32(),
+                    UnknownFloat_18  = reader.ReadSingle()
+                };
+                Materials.Add(material);
+            }
+
+            // Meshes
+            reader.JumpTo(MeshesOffset);
+            for (int i = 0; i < MeshCount; i++)
+            {
+                Mesh mesh = new Mesh
+                {
+                    Material          = new string(reader.ReadChars(68)),
+                    UnknownUInt32_1   = reader.ReadUInt32(),
+                    UnknownUInt32_2   = reader.ReadUInt32(),
+                    UnknownUInt32_3   = reader.ReadUInt32(),
+                    FaceTablePosition = reader.ReadUInt32(),
+                    FaceCount         = reader.ReadUInt32(),
+                    UnknownUInt32_4   = reader.ReadUInt32()
+                };
+                Meshes.Add(mesh);
+            }
+        }
+
+        public unsafe override void Save(Stream fileStream)
+        {
+            ExtendedBinaryWriter writer = new ExtendedBinaryWriter(fileStream, true);
+
+            // Header and Offsets
+            writer.WriteSignature(Signature);
+            writer.WriteNulls(1);
+            writer.Write(0x60);
+            writer.Write(0x20);
+            writer.AddOffset("VerticiesOffset");
+            writer.Write(Vertices.Count * 32);
+            writer.AddOffset("FacesOffset");
+            writer.Write(Faces.Count * 3);
+            writer.AddOffset("TexturesOffset");
+            writer.Write(Textures.Count);
+            writer.AddOffset("MaterialsOffset");
+            writer.Write(Materials.Count);
+            writer.AddOffset("MeshesOffset");
+            writer.Write(Meshes.Count);
+            writer.Write(BoundingBox.Minimum);
+            writer.Write(BoundingBox.Maximum);
+
+            // Unknown Bytes
+            for(int i = 0; i < UnknownBytes.Count; i++) { writer.Write(UnknownBytes[i]); }
+
+            // Verticies
+            writer.FillInOffset("VerticiesOffset");
+            for (int i = 0; i < Vertices.Count; i++)
+            {
+                writer.Write(Vertices[i].Position);
+                writer.Write(Vertices[i].UnknownUInt32_1);
+                writer.Write(Vertices[i].UnknownUInt32_2);
+                writer.Write(Vertices[i].VertexColour.Red);
+                writer.Write(Vertices[i].VertexColour.Green);
+                writer.Write(Vertices[i].VertexColour.Blue);
+                writer.Write(Vertices[i].VertexColour.Alpha);
+
+                // Really hacky code to get around the lack of Half support, should be able to clean this up when Hyper commits Half support
+                var halfHackValue = Vertices[i].XTextureCoordinate;
+                var halfHack = *((ushort*)&halfHackValue);
+                writer.Write(halfHack);
+                halfHackValue = Vertices[i].YTextureCoordinate;
+                halfHack = *((ushort*)&halfHackValue);
+                writer.Write(halfHack);
+
+                writer.Write(Vertices[i].UnknownUInt32_3);
+            }
+
+            // Faces
+            writer.FillInOffset("FacesOffset");
+            for (int i = 0; i < Faces.Count; i++)
+            {
+                writer.Write(Faces[i].Vertex1);
+                writer.Write(Faces[i].Vertex2);
+                writer.Write(Faces[i].Vertex3);
+            }
+            writer.FixPadding();
+
+            // Textures
+            writer.FillInOffset("TexturesOffset");
+            for (int i = 0; i < Textures.Count; i++)
+            {
+                writer.Write(Textures[i].Name.PadRight(76, '\0'));
+                writer.Write(Textures[i].UnknownUInt32_1);
+                writer.Write(Textures[i].UnknownUInt32_2);
+                writer.Write(Textures[i].UnknownUInt32_3);
+                writer.Write(Textures[i].UnknownUInt32_4);
+                writer.Write(Textures[i].TextureID);
+                writer.Write(Textures[i].TextureType);
+            }
+
+            // Materials
+            writer.FillInOffset("MaterialsOffset");
+            for (int i = 0; i < Materials.Count; i++)
+            {
+                writer.Write(Materials[i].Name.PadRight(60, '\0'));
+                writer.Write(Materials[i].UnknownUInt32_1);
+                writer.Write(Materials[i].EffectFile.PadRight(60, '\0'));
+                writer.Write(Materials[i].UnknownUInt32_2);
+                writer.Write(Materials[i].EffectTechnique.PadRight(60, '\0'));
+                writer.Write(Materials[i].UnknownUInt32_3);
+                writer.Write(Materials[i].UnknownFloat_1);
+                writer.Write(Materials[i].UnknownFloat_2);
+                writer.Write(Materials[i].UnknownFloat_3);
+                writer.Write(Materials[i].UnknownFloat_4);
+                writer.Write(Materials[i].UnknownFloat_5);
+                writer.Write(Materials[i].UnknownFloat_6);
+                writer.Write(Materials[i].UnknownFloat_7);
+                writer.Write(Materials[i].UnknownFloat_8);
+                writer.Write(Materials[i].UnknownFloat_9);
+                writer.Write(Materials[i].UnknownFloat_10);
+                writer.Write(Materials[i].UnknownFloat_11);
+                writer.Write(Materials[i].UnknownFloat_12);
+                writer.Write(Materials[i].UnknownFloat_13);
+                writer.Write(Materials[i].UnknownFloat_14);
+                writer.Write(Materials[i].UnknownFloat_15);
+                writer.Write(Materials[i].UnknownFloat_16);
+                writer.Write(Materials[i].UnknownFloat_17);
+                writer.Write(Materials[i].TextureFile1.PadRight(60, '\0'));
+                writer.Write(Materials[i].UnknownUInt32_4);
+                writer.Write(Materials[i].TextureFile2.PadRight(60, '\0'));
+                writer.Write(Materials[i].UnknownUInt32_5);
+                writer.Write(Materials[i].TextureFile3.PadRight(60, '\0'));
+                writer.Write(Materials[i].UnknownUInt32_6);
+                writer.Write(Materials[i].TextureFile4.PadRight(60, '\0'));
+                writer.Write(Materials[i].UnknownUInt32_7);
+                writer.Write(Materials[i].UnknownUInt32_8);
+                writer.Write(Materials[i].UnknownUInt32_9);
+                writer.Write(Materials[i].BackfaceCull);
+                writer.Write(Materials[i].UnknownUInt32_11);
+                writer.Write(Materials[i].UnknownUInt32_12);
+                writer.Write(Materials[i].UnknownUInt32_13);
+                writer.Write(Materials[i].UnknownUInt32_14);
+                writer.Write(Materials[i].UnknownFloat_18);
+            }
+
+            // Meshes
+            writer.FillInOffset("MeshesOffset");
+            for (int i = 0; i < Meshes.Count; i++)
+            {
+                writer.Write(Meshes[i].Material.PadRight(68, '\0'));
+                writer.Write(Meshes[i].UnknownUInt32_1);
+                writer.Write(Meshes[i].UnknownUInt32_2);
+                writer.Write(Meshes[i].UnknownUInt32_3);
+                writer.Write(Meshes[i].FaceTablePosition);
+                writer.Write(Meshes[i].FaceCount);
+                writer.Write(Meshes[i].UnknownUInt32_4);
+            }
+        }
+
+        // TODO: Make this actually, oh I don't know...
+        // WORK?
+        public void ExportOBJ(string filepath)
+        {
+            // OBJ.
+            using (StreamWriter obj = new StreamWriter(filepath))
+            {
+                obj.WriteLine($"mtllib {Path.GetFileNameWithoutExtension(filepath)}.mtl\n");
+
+                // Verticies
+                foreach(Vertex vertex in Vertices)
+                {
+                    obj.WriteLine($"v {vertex.Position.X} {vertex.Position.Y} {vertex.Position.Z}");
+                }
+                obj.WriteLine();
+
+                // Texture Coordinates
+                foreach (Vertex vertex in Vertices)
+                {
+                    obj.WriteLine($"vt {vertex.XTextureCoordinate} {vertex.YTextureCoordinate}");
+                }
+                obj.WriteLine();
+
+                // Vertex Colours
+                foreach (Vertex vertex in Vertices)
+                {
+                    obj.WriteLine($"vc {vertex.VertexColour.Red} {vertex.VertexColour.Green} {vertex.VertexColour.Blue} {vertex.VertexColour.Alpha}");
+                }
+                obj.WriteLine();
+
+                // Objects
+                for (int i = 0; i < Meshes.Count; i++)
+                {
+                    obj.WriteLine($"g {Path.GetFileNameWithoutExtension(filepath)}_Mesh{i}");
+                    obj.WriteLine($"usemtl {Meshes[i].Material.Replace("\0", "")}");
+                    for(int f = 0; f < Meshes[i].FaceCount; f++)
+                    {
+                        obj.WriteLine($"f {Faces[f + (int)(Meshes[i].FaceTablePosition / 3)].Vertex1 + 1}/{Faces[f + (int)(Meshes[i].FaceTablePosition / 3)].Vertex1 + 1} {Faces[f + (int)(Meshes[i].FaceTablePosition / 3)].Vertex2 + 1}/{Faces[f + (int)(Meshes[i].FaceTablePosition / 3)].Vertex2 + 1} {Faces[f + (int)(Meshes[i].FaceTablePosition / 3)].Vertex3 + 1}/{Faces[f + (int)(Meshes[i].FaceTablePosition / 3)].Vertex3 + 1}");
+                    }
+                }
+            }
+
+            // MTL.
+            using (StreamWriter mtl = new StreamWriter($"{Path.GetDirectoryName(filepath)}\\{Path.GetFileNameWithoutExtension(filepath)}.mtl"))
+            {
+                foreach(Material material in Materials)
+                {
+                    mtl.WriteLine($"newmtl {material.Name.Replace("\0", "")}");
+                    mtl.WriteLine("Ka 0.2 0.2 0.2");
+                    mtl.WriteLine("Kd 0.8 0.8 0.8");
+                    mtl.WriteLine("Ks 0 0 0");
+                    mtl.WriteLine("Ns 10");
+                    mtl.WriteLine("d 1.0");
+                    mtl.WriteLine("illum 4");
+                    mtl.WriteLine($"map_Kd {material.TextureFile1.Replace("\0", "")}\n");
+                }
+            }
+        }
+
+        public void ImportAssimp(string srcFile, string donorFile)
+        {
+            // TODO: Test other file formats, currently only know about FBX support. Cleanup Code.
+            // Setup Assimp scene and load the srcFile.
+            AssimpContext assimpImporter = new AssimpContext();
+            Scene assimpModel = assimpImporter.ImportFile(srcFile, PostProcessSteps.PreTransformVertices);
+
+            // Setup and load the donor model from donorFile.
+            SOXModel donorMdl = new SOXModel();
+            donorMdl.Load(donorFile);
+
+            // Bounding Box (TODO: Unhardcode these values in someway?)
+            BoundingBox.Minimum = new Vector3(-999999f, -999999f, -999999f);
+            BoundingBox.Maximum = new Vector3(999999f, 999999f, 999999f);
+
+            // Unknown Bytes (TODO: Research these so a donor model isn't needed.)
+            UnknownBytes = donorMdl.UnknownBytes;
+
+            for (int m = 0; m < assimpModel.MeshCount; m++)
+            {
+                // Vertices (TODO: Unhardcode UnknownUInts so a donor model isn't needed, update Half setup once Hyper commits that support.)
+                int previousVertexCount = Vertices.Count;
+                Vertex vertex;
+                for (int i = 0; i < assimpModel.Meshes[m].Vertices.Count; i++)
+                {
+                    vertex = new Vertex();
+                    vertex.Position = new Vector3(assimpModel.Meshes[m].Vertices[i].X, assimpModel.Meshes[m].Vertices[i].Y, assimpModel.Meshes[m].Vertices[i].Z);
+                    if (assimpModel.Meshes[m].VertexColorChannelCount != 0)
+                    {
+                        vertex.VertexColour.Red   = Convert.ToByte(assimpModel.Meshes[m].VertexColorChannels[0][i].R * 255);
+                        vertex.VertexColour.Green = Convert.ToByte(assimpModel.Meshes[m].VertexColorChannels[0][i].G * 255);
+                        vertex.VertexColour.Blue  = Convert.ToByte(assimpModel.Meshes[m].VertexColorChannels[0][i].B * 255);
+                        vertex.VertexColour.Alpha = Convert.ToByte(assimpModel.Meshes[m].VertexColorChannels[0][i].A * 255);
+                    }
+                    else
+                    {
+                        vertex.VertexColour.Red   = Convert.ToByte(255);
+                        vertex.VertexColour.Green = Convert.ToByte(255);
+                        vertex.VertexColour.Blue  = Convert.ToByte(255);
+                        vertex.VertexColour.Alpha = Convert.ToByte(255);
+                    }
+                    vertex.XTextureCoordinate = (Half)assimpModel.Meshes[m].TextureCoordinateChannels[0][i].X;
+                    vertex.YTextureCoordinate = (Half)(-assimpModel.Meshes[m].TextureCoordinateChannels[0][i].Y);
+                    vertex.UnknownUInt32_1 = donorMdl.Vertices[0].UnknownUInt32_1;
+                    vertex.UnknownUInt32_2 = donorMdl.Vertices[0].UnknownUInt32_2;
+                    vertex.UnknownUInt32_3 = donorMdl.Vertices[0].UnknownUInt32_3;
+                    Vertices.Add(vertex);
+                }
+
+                // Meshes (TODO: Research and unhardcode UnknownUInts.)
+                Mesh mesh = new Mesh();
+                if (assimpModel.Materials[m].Name.Contains("@"))
+                {
+                    mesh.Material = assimpModel.Materials[m].Name.Remove(assimpModel.Materials[m].Name.IndexOf('@'));
+                }
+                else
+                {
+                    mesh.Material = assimpModel.Materials[m].Name;
+                }
+                mesh.UnknownUInt32_1 = 3u;
+                mesh.UnknownUInt32_2 = 0x00000000;
+                mesh.UnknownUInt32_3 = 0x00000B75;
+                mesh.FaceTablePosition = Convert.ToUInt32(Faces.Count * 3);
+                mesh.FaceCount = Convert.ToUInt32(assimpModel.Meshes[m].FaceCount);
+                mesh.UnknownUInt32_4 = 0;
+                Meshes.Add(mesh);
+
+                // Faces.
+                Face face;
+                foreach (Assimp.Face assimpFace in assimpModel.Meshes[m].Faces)
+                {
+                    face = new Face
+                    {
+                        Vertex1 = (ushort)(assimpFace.Indices[0] + previousVertexCount),
+                        Vertex2 = (ushort)(assimpFace.Indices[1] + previousVertexCount),
+                        Vertex3 = (ushort)(assimpFace.Indices[2] + previousVertexCount)
+                    };
+                    Faces.Add(face);
+                }
+            }
+
+            for (int m = 0; m < assimpModel.MaterialCount; m++)
+            {
+                // Textures (TODO: Research and unhardcode UnknownUInts.)
+                Texture texture = new Texture
+                {
+                    Name = assimpModel.Materials[m].TextureDiffuse.FilePath.Substring(assimpModel.Materials[m].TextureDiffuse.FilePath.LastIndexOf('\\') + 1),
+                    UnknownUInt32_1 = 2,
+                    UnknownUInt32_2 = 0,
+                    UnknownUInt32_3 = 0,
+                    UnknownUInt32_4 = 1,
+                    TextureID = Convert.ToUInt32(m),
+                    TextureType = 2
+                };
+                Textures.Add(texture);
+
+                // Materials (TODO: Research and unhardcode unknown values so a donor model isn't needed.)
+                Material material = new Material();
+                material.EffectFile = "Billboard03.fx";
+                material.EffectTechnique = "Billboard03";
+                if (assimpModel.Materials[m].Name.Contains("@"))
+                {
+                    material.Name = assimpModel.Materials[m].Name.Remove(assimpModel.Materials[m].Name.IndexOf('@'));
+                }
+                else
+                {
+                    material.Name = assimpModel.Materials[m].Name;
+                }
+                material.TextureFile1 = assimpModel.Materials[m].TextureDiffuse.FilePath.Substring(assimpModel.Materials[m].TextureDiffuse.FilePath.LastIndexOf('\\') + 1);
+                material.TextureFile2 = "";
+                material.TextureFile3 = "";
+                material.TextureFile4 = "";
+                //material.UnknownFloat_4 = material.UnknownFloat_12 = material.UnknownFloat_16 = 1f;
+                material.UnknownFloat_1 = donorMdl.Materials[0].UnknownFloat_1;
+                material.UnknownFloat_2 = donorMdl.Materials[0].UnknownFloat_2;
+                material.UnknownFloat_3 = donorMdl.Materials[0].UnknownFloat_3;
+                material.UnknownFloat_4 = donorMdl.Materials[0].UnknownFloat_4;
+                material.UnknownFloat_5 = donorMdl.Materials[0].UnknownFloat_5;
+                material.UnknownFloat_6 = donorMdl.Materials[0].UnknownFloat_6;
+                material.UnknownFloat_7 = donorMdl.Materials[0].UnknownFloat_7;
+                material.UnknownFloat_8 = donorMdl.Materials[0].UnknownFloat_8;
+                material.UnknownFloat_9 = donorMdl.Materials[0].UnknownFloat_9;
+                material.UnknownFloat_10 = donorMdl.Materials[0].UnknownFloat_10;
+                material.UnknownFloat_11 = donorMdl.Materials[0].UnknownFloat_11;
+                material.UnknownFloat_12 = donorMdl.Materials[0].UnknownFloat_12;
+                material.UnknownFloat_13 = donorMdl.Materials[0].UnknownFloat_13;
+                material.UnknownFloat_14 = donorMdl.Materials[0].UnknownFloat_14;
+                material.UnknownFloat_15 = donorMdl.Materials[0].UnknownFloat_15;
+                material.UnknownFloat_16 = donorMdl.Materials[0].UnknownFloat_16;
+                material.UnknownFloat_17 = donorMdl.Materials[0].UnknownFloat_17;
+                material.UnknownFloat_18 = donorMdl.Materials[0].UnknownFloat_18;
+                material.UnknownUInt32_1 = donorMdl.Materials[0].UnknownUInt32_1;
+                material.UnknownUInt32_2 = donorMdl.Materials[0].UnknownUInt32_2;
+                material.UnknownUInt32_3 = donorMdl.Materials[0].UnknownUInt32_3;
+                material.UnknownUInt32_4 = donorMdl.Materials[0].UnknownUInt32_4;
+                material.UnknownUInt32_5 = donorMdl.Materials[0].UnknownUInt32_5;
+                material.UnknownUInt32_6 = donorMdl.Materials[0].UnknownUInt32_6;
+                material.UnknownUInt32_7 = donorMdl.Materials[0].UnknownUInt32_7;
+                material.UnknownUInt32_8 = donorMdl.Materials[0].UnknownUInt32_8;
+                material.UnknownUInt32_9 = donorMdl.Materials[0].UnknownUInt32_9;
+                material.BackfaceCull = donorMdl.Materials[0].BackfaceCull;
+                material.UnknownUInt32_11 = donorMdl.Materials[0].UnknownUInt32_11;
+                material.UnknownUInt32_12 = donorMdl.Materials[0].UnknownUInt32_12;
+                material.UnknownUInt32_13 = donorMdl.Materials[0].UnknownUInt32_13;
+                material.UnknownUInt32_14 = donorMdl.Materials[0].UnknownUInt32_14;
+                Materials.Add(material);
+            }
+        }
+    }
+}

--- a/Marathon.IO/Formats/Meshes/SegaNNXbox.cs
+++ b/Marathon.IO/Formats/Meshes/SegaNNXbox.cs
@@ -1,0 +1,869 @@
+﻿using System;
+using System.IO;
+using System.Collections.Generic;
+using Marathon.IO.Exceptions;
+
+namespace Marathon.IO.Formats.Meshes
+{
+    // TODO: Maybe try to complete this for once, even if it's just reading? Being able to write back binary identical data will be useful for research.
+    // Understand the Footer Nodes.
+    // Study en_Kyozoress.xtv for dynamic material animations
+    public class SegaNNXbox : FileBase
+    {
+        // NXTL
+        public class NinjaTextureFile
+        {
+            public string Filename;
+            public uint Filter;
+        }
+
+        // NXEF
+        public class NinjaEffectList
+        {
+            public uint Type;
+            public List<NinjaEffectFile> EffectFileList = new List<NinjaEffectFile>();
+            public List<NinjaTechniqueName> EffectTechniqueList = new List<NinjaTechniqueName>();
+            public List<short> TechniqueIDList = new List<short>();
+        }
+        public class NinjaEffectFile
+        {
+            public uint Type;
+            public string Filename;
+        }
+        public class NinjaTechniqueName
+        {
+            public uint Type;
+            public string Name;
+        }
+
+        // NXNN
+        public class NinjaNodeNameList
+        {
+            public uint Type;
+            public List<string> NodeNameList = new List<string>();
+        }
+
+        // NXOB
+        public class NinjaObject
+        {
+            public Vector3 Center;
+            public float Radius;
+            public List<NinjaObjectMaterial> MaterialList = new List<NinjaObjectMaterial>();
+            public List<NinjaObjectVertex> VertexList = new List<NinjaObjectVertex>();
+            public List<NinjaObjectPrimitive> PrimitiveList = new List<NinjaObjectPrimitive>();
+            public uint MaxNodeDepth;
+            public List<NinjaObjectNode> NodeList = new List<NinjaObjectNode>();
+            public uint MatrixPAL; // TODO: Figure out what this stands for. Matrix Something?
+            public List<NinjaSubObject> SubObjectList = new List<NinjaSubObject>();
+        }
+        public class NinjaObjectMaterial
+        {
+            public uint Type;
+            // NNS_MATERIAL_DESC Values.
+            public uint Description_Flag;
+            public uint Description_UserDefined;
+            // NNS_MATERIAL_COLOR Values.
+            public Vector4 Colour_Diffuse;
+            public Vector4 Colour_Ambient;
+            public Vector4 Colour_Specular;
+            public Vector4 Colour_Emissive;
+            public float Colour_Power;
+            // NNS_MATERIAL_LOGIC Values.
+            public bool Logic_BlendEnable;
+            public uint Logic_SRCBlend; // TODO: Figure out what SRC means.
+            public uint Logic_DSTBlend; // TODO: Figure out what DST means.
+            public uint Logic_BlendFactor;
+            public uint Logic_BlendOP; // TODO: Figure out what the OP part means. Blend Operation?
+            public uint Logic_LogicOP; // TODO: Figure out what the OP part means. Logic Operation?
+            public bool Logic_AlphaEnable;
+            public uint Logic_AlphaFunction;
+            public uint Logic_AlphaRef; // TODO: Figure out what the Ref part means. Alpha Reflectivity?
+            public bool Logic_ZCompEnable; // TODO: Figure out what the ZComp part means. Z-Compensation?
+            public uint Logic_ZFunction;
+            public bool Logic_ZUpdateEnable;
+            // NNS_MATERIAL_TEXMAP2_DESC Values.
+            public uint Texture_Type;
+            public uint Texture_ID;
+            public Vector2 Texture_Offset;
+            public float Texture_Blend;
+            public uint Texture_MinFilter; // TODO: Find out what the Min part means. All set to NND_MIN_LINEAR_MIPMAP_NEAREST in the XTO.
+            public uint Texture_MagFilter; // TODO: Find out what the Mag part means. All set to NND_MAG_LINEAR in the XTO.
+            public float Texture_MipMapBias;
+            public uint Texture_MaxMipMapLevel;
+        }
+        public class NinjaObjectVertex
+        {
+            public uint Type;
+            // NNS_VTXLIST_DX_DESC Values.
+            public uint Description_Format;
+            public uint Description_FVF; // TODO: Find out what the FVF part means.
+            public uint Description_HDRCommon;
+            public uint Description_HDRData;
+            public uint Description_HDRLock;
+            public List<NinjaObjectVertexXB> VertexList = new List<NinjaObjectVertexXB>();
+            public List<int> BoneMatrix = new List<int>();
+        }
+        public class NinjaObjectVertexXB // Temp Name
+        {
+            // NNS_VTXTYPE_XB_??? Values.
+            public Vector3 List_Position;
+            public Vector3 List_Weight;
+            public List<byte> List_BoneMatrix = new List<byte>(); // Just based on what I'm seeing from the MaxScript and LibS06.
+            public Vector3 List_Normals;
+            public List<byte> List_VertexColour = new List<byte>();
+            public List<Vector2> List_TextureCoordinates = new List<Vector2>();
+            public Vector3 List_Tangent;
+            public Vector3 List_Binormal;
+        }
+        public class NinjaObjectPrimitive
+        {
+            public uint Type;
+            // NNS_PRIMTYPE_DX_STRIPLIST Values
+            public uint SList_Format;
+            public List<ushort> SList_Index = new List<ushort>();
+        }
+        public class NinjaObjectNode
+        {
+            public uint Type;
+            public ushort Matrix;
+            public ushort Parent;
+            public ushort Child;
+            public ushort Sibling;
+            public Vector3 Transform;
+            public Vector3 Rotation;
+            public Vector3 Scale; // Can only assume that's what SCL stands for.
+            public List<float> InvinitMatrix = new List<float>(); // TODO: Find out what Invinit means.
+            public Vector3 Center;
+            public float Radius;
+            public uint UserDefined; // Always 0 in the XTO?
+            public Vector3 BoundingBox; // The XTO usually has three RSV (reserved?) values here, but two nodes seem to have Bounding Boxes instead.
+        }
+        public class NinjaSubObject
+        {
+            public uint Type;
+            public List<NinjaSubObjectMeshSet> MeshSets = new List<NinjaSubObjectMeshSet>();
+            public List<int> TextureList = new List<int>();
+        }
+        public class NinjaSubObjectMeshSet
+        {
+            // NNS_MESHSET Values.
+            public Vector3 Center;
+            public float Radius;
+            public uint NodeID;
+            public uint Matrix;
+            public uint MaterialID;
+            public uint VertexID;
+            public uint PrimitiveID;
+            public uint ShaderID;
+        }
+
+        public class NinjaMotion
+        {
+            public uint Type;
+            public float StartFrame;
+            public float EndFrame;
+            public List<NinjaSubMotion> SubMotions = new List<NinjaSubMotion>();
+            public float Framerate;
+            public uint Reserved0;
+            public uint Reserved1;
+        }
+        public class NinjaSubMotion
+        {
+            public uint SubMot_Type;
+            public uint SubMot_IPType; // TODO: Find out what IP means in this context.
+            public uint SubMot_ID;
+            public float SubMot_StartFrame;
+            public float SubMot_EndFrame;
+            public float SubMot_StartKey;
+            public float SubMot_EndKey;
+            public List<NinjaSubMotionKey> SubMot_KeyList = new List<NinjaSubMotionKey>();
+        }
+        public class NinjaSubMotionKey
+        {
+            public float Key_Translation_MFRM;
+            public float Key_Translation_MVAL;
+            public short Key_Rotation_MFRM;
+            public Half Key_Rotation_MVAL;
+            public float Key_Diffuse_MFRM;
+            public Vector3 Key_Diffuse_MVAL;
+        }
+
+
+        // Declare the Lists, but don't create them, as not every list is used by every SegaNN file.
+        public List<NinjaTextureFile> _NinjaTextureFileList;
+        public NinjaEffectList        _NinjaEffectList;
+        public NinjaNodeNameList      _NinjaNodeNameList;
+        public NinjaObject            _NinjaObject;
+        public NinjaMotion            _NinjaMotion;
+
+        public override void Load(Stream fileStream)
+        {
+            ExtendedBinaryReader reader = new ExtendedBinaryReader(fileStream) { Offset = 0x20 };
+
+            // Info Node
+            string InfoNodeType  = new string(reader.ReadChars(4)); // The Type of this Info Node.
+            if (InfoNodeType != "NXIF")
+                throw new InvalidSignatureException("NXIF", InfoNodeType); // Only supporting XN* (for now?).
+            uint NodeLength      = reader.ReadUInt32();             // The length of the Info Node.
+            uint NodeCount       = reader.ReadUInt32();             // How many other Nodes make up this NN file.
+            uint UnknownUInt32_1 = reader.ReadUInt32();             // Seems to always be 0x20 (at least in XN*s)? Offset amount?
+            uint UnknownUInt32_2 = reader.ReadUInt32();             // Footer Offset Table Start?
+            uint UnknownUInt32_3 = reader.ReadUInt32();             // Footer Offset Table Data Start?
+            uint UnknownUInt32_4 = reader.ReadUInt32();             // Footer Offset Table Length?
+            uint UnknownUInt32_5 = reader.ReadUInt32();             // Seems to always be 1 (at least in XN*s)?
+
+            // Loop through nodes.
+            for (int i = 0; i < NodeCount; i++)
+            {
+                // Determine type of node to read and its length
+                string NextNodeType = new string(reader.ReadChars(4));
+                uint NextNodeLength = reader.ReadUInt32();
+                reader.JumpBehind(8);
+
+                switch (NextNodeType)
+                {
+                    case "NXTL":
+                        ReadNinjaTextureList(reader);
+                        break;
+                    case "NXEF":
+                        ReadNinjaEffectList(reader);
+                        break;
+                    case "NXNN":
+                        ReadNinjaNodeNameList(reader);
+                        break;
+                    case "NXOB":
+                        ReadNinjaObject(reader);
+                        break;
+                    case "NXMO":
+                    case "NXMA":
+                        ReadNinjaMotion(reader);
+                        break;
+                    default:
+                        reader.JumpAhead(8);
+                        reader.JumpAhead(NextNodeLength);
+                        Console.WriteLine($"Block {NextNodeType} Not Implemented!");
+                        break;
+                }
+            }
+
+            // TODO: Read Footer.
+        }
+
+        public void ReadNinjaTextureList(ExtendedBinaryReader reader)
+        {
+            // Create the _NinjaTextureFileList so we can write to it.
+            _NinjaTextureFileList = new List<NinjaTextureFile>();
+
+            string TextureListNodeType = new string(reader.ReadChars(4)); // The type of this Texture List Node.
+            uint NodeLength            = reader.ReadUInt32();             // The length of this Node.
+            long returnPosition        = reader.BaseStream.Position;      // Save position so we can use it with the length to jump to the next Node afterwards.
+            uint NodeOffset            = reader.ReadUInt32();             // Where this Node's Data starts.
+
+            // Jump to the texture node's data.
+            reader.JumpTo(NodeOffset, true);
+
+            uint TextureCount      = reader.ReadUInt32(); // The amount of texture data in this Node.
+            uint TextureListOffset = reader.ReadUInt32(); // The offset to the texture data in this Node.
+
+            // Jump to the texture list.
+            reader.JumpTo(TextureListOffset, true);
+
+            // Loop through based on amount of textures in this Node.
+            for (int i = 0; i < TextureCount; i++)
+            {
+                NinjaTextureFile _NinjaTextureFile = new NinjaTextureFile();
+                uint UnknownUInt32_1               = reader.ReadUInt32(); // Unknown, not referenced in the XTO file.
+                uint TextureNameOffset             = reader.ReadUInt32(); // The offset to this texture's Filename.
+                _NinjaTextureFile.Filter           = reader.ReadUInt32(); // The flags for this texture's Filter Settings.
+                uint UnknownUInt32_2               = reader.ReadUInt32(); // Unknown, not referenced in the XTO file.
+                uint UnknownUInt32_3               = reader.ReadUInt32(); // Unknown, not referenced in the XTO file.
+
+                // Store current position to jump back to for the next texture.
+                long position = reader.BaseStream.Position;
+
+                // Jump to and read this texture's Filename.
+                reader.JumpTo(TextureNameOffset, true);
+                _NinjaTextureFile.Filename = reader.ReadNullTerminatedString();
+
+                // Jump back to the saved position to read the next texture.
+                reader.JumpTo(position);
+
+                // Save texture entry into the _NinjaTextureFileList.
+                _NinjaTextureFileList.Add(_NinjaTextureFile);
+            }
+
+            // Return to the previously saved position and jump ahead by NodeLength to place us at the next node.
+            reader.JumpTo(returnPosition);
+            reader.JumpAhead(NodeLength);
+        }
+
+        public void ReadNinjaEffectList(ExtendedBinaryReader reader)
+        {
+            // Create the _NinjaEffectList so we can write to it.
+            _NinjaEffectList = new NinjaEffectList();
+
+            string EffectListNodeType = new string(reader.ReadChars(4)); // The Type of this Effect List Node.
+            uint NodeLength           = reader.ReadUInt32();             // The length of this Node.
+            long returnPosition       = reader.BaseStream.Position;      // Save position so we can use it with the length to jump to the next Node afterwards.
+            uint NodeOffset           = reader.ReadUInt32();             // Where this Node's Data starts.
+
+            // Jump to the effect node's data.
+            reader.JumpTo(NodeOffset, true);
+
+            _NinjaEffectList.Type     = reader.ReadUInt32(); // The type of effect list this Node is.
+            uint EffectFilesCount     = reader.ReadUInt32(); // The amount of effect files in this effect list.
+            uint EffectFilesOffset    = reader.ReadUInt32(); // The offset to the effect files in this effect list.
+            uint TechniqueNamesCount  = reader.ReadUInt32(); // The amount of technique names in this effect list.
+            uint TechniqueNamesOffset = reader.ReadUInt32(); // The offset to the technique names in this effect list.
+            uint TechniqueIDsCount    = reader.ReadUInt32(); // The amount of technique ID entries in this effect list.
+            uint TechniqueIDsOffset   = reader.ReadUInt32(); // The offset to the technique ID data in this effect list.
+
+            // Effect Files.
+            // Jump to the effect files in this effect list.
+            reader.JumpTo(EffectFilesOffset, true);
+
+            // Loop through based on amount of effect files in this effect list.
+            for (int i = 0; i < EffectFilesCount; i++)
+            {
+                NinjaEffectFile _NinjaEffectFile = new NinjaEffectFile();
+                _NinjaEffectFile.Type     = reader.ReadUInt32(); // The type of effect file this is.
+                uint EffectFilenameOffset = reader.ReadUInt32(); // The offset to this effect file's Filename.
+
+                // Store current position to jump back to for the next effect file.
+                long position = reader.BaseStream.Position;
+
+                // Jump to and read this effect file's Filename.
+                reader.JumpTo(EffectFilenameOffset, true);
+                _NinjaEffectFile.Filename = reader.ReadNullTerminatedString();
+
+                // Jump back to the saved position to read the next effect file.
+                reader.JumpTo(position);
+
+                // Save effect file entry into EffectFileList in the _NinjaEffectList.
+                _NinjaEffectList.EffectFileList.Add(_NinjaEffectFile);
+            }
+
+            // Effect Technique
+            // Jump to the technique data in this Node.
+            reader.JumpTo(TechniqueNamesOffset, true);
+
+            // Loop through based on amount of techniques in this Node.
+            for (int i = 0; i < TechniqueNamesCount; i++)
+            {
+                NinjaTechniqueName _NinjaTechniqueName = new NinjaTechniqueName();
+                _NinjaTechniqueName.Type               = reader.ReadUInt32(); // The type of technique this is.
+                uint EffectFileID                      = reader.ReadUInt32(); // The ID of this this technique's effect file, always linear.
+                uint TechniqueNameOffset               = reader.ReadUInt32(); // The offset to this technique's Filename.
+
+                // Store current position to jump back to for the next technique.
+                long currentPos = reader.BaseStream.Position;
+
+                // Jump to and read this technique's Filename.
+                reader.JumpTo(TechniqueNameOffset, true);
+                _NinjaTechniqueName.Name = reader.ReadNullTerminatedString();
+
+                // Jump back to the saved position to read the next technique.
+                reader.JumpTo(currentPos);
+
+                // Save technique entry into EffectTechniqueList in the _NinjaEffectList.
+                _NinjaEffectList.EffectTechniqueList.Add(_NinjaTechniqueName);
+            }
+
+            // Technique IDs
+            // Jump to the technique ID data in this Node.
+            reader.JumpTo(TechniqueIDsOffset, true);
+
+            // Loop through based on amount of technique ID entries in this Node and save them into TechniqueIDList in the _NinjaEffectList.
+            for (int i = 0; i < TechniqueIDsCount; i++)
+                _NinjaEffectList.TechniqueIDList.Add(reader.ReadInt16());
+
+            // Return to the previously saved position and jump ahead by NodeLength to place us at the next node.
+            reader.JumpTo(returnPosition);
+            reader.JumpAhead(NodeLength);
+        }
+
+        public void ReadNinjaNodeNameList(ExtendedBinaryReader reader)
+        {
+            // Create the _NinjaNodeNameList so we can write to it.
+            _NinjaNodeNameList = new NinjaNodeNameList();
+
+            string NodeNameListNodeType = new string(reader.ReadChars(4)); // The Type of this Node Name List Node.
+            uint NodeLength             = reader.ReadUInt32();             // Length of this Node.
+            long returnPosition         = reader.BaseStream.Position;      // Save position so we can use it with the length to jump to the next Node afterwards.
+            uint NodeOffset             = reader.ReadUInt32();             // Where this Node's Data starts.
+
+            // Jump to the name list node's data.
+            reader.JumpTo(NodeOffset, true);
+
+            _NinjaNodeNameList.Type   = reader.ReadUInt32(); // The type of node name list this is.
+            uint NodeListEntriesCount = reader.ReadUInt32(); // How many name entries exist in this Node.
+            uint NodeListOffset       = reader.ReadUInt32(); // The offset to the node list.
+
+            // Jump to the node table in this Node.
+            reader.JumpTo(NodeListOffset, true);
+
+            // Loop through based on amount of nodes in this Node.
+            for (int i = 0; i < NodeListEntriesCount; i++)
+            {
+                uint NodeID         = reader.ReadUInt32(); // The ID of the current node, always linear.
+                uint NodeTypeOffset = reader.ReadUInt32(); // The offset to this node's name.
+
+                // Store current position to jump back to for the next technique.
+                long position = reader.BaseStream.Position;
+
+                // Jump to and read this node's name.
+                reader.JumpTo(NodeTypeOffset, true);
+                string NodeName = reader.ReadNullTerminatedString();
+
+                // Jump back to the saved position to read the next node.
+                reader.JumpTo(position);
+
+                // Save the node name into the NodeNameList in the _NinjaNodeNameList.
+                _NinjaNodeNameList.NodeNameList.Add(NodeName);
+            }
+
+            // Return to the previously saved position and jump ahead by NodeLength to place us at the next node.
+            reader.JumpTo(returnPosition);
+            reader.JumpAhead(NodeLength);
+        }
+
+        public void ReadNinjaObject(ExtendedBinaryReader reader)
+        {
+            // Create the _NinjaObject so we can write to it.
+            _NinjaObject = new NinjaObject();
+
+            string NodeObjectNodeType = new string(reader.ReadChars(4)); // The Type of this Object Node.
+            uint NodeLength           = reader.ReadUInt32();             // Length of this Node.
+            long returnPosition       = reader.BaseStream.Position;      // Save position so we can use it with the length to jump to the next Node afterwards.
+            uint NodeOffset           = reader.ReadUInt32();             // Where this Node's Data starts.
+
+            // Jump to the object node's data.
+            reader.JumpTo(NodeOffset, true);
+
+            // Read object data, counts and pointers.
+            _NinjaObject.Center       = reader.ReadVector3(); // The center point of this object.
+            _NinjaObject.Radius       = reader.ReadSingle();  // The radius this object takes up?
+            uint MaterialCount        = reader.ReadUInt32();  // The amount of materials specified in this object.
+            uint MaterialListOffset   = reader.ReadUInt32();  // The offset to this object's material list.
+            uint VertexCount          = reader.ReadUInt32();  // The amount of verticies specified in this object.
+            uint VertexListOffset     = reader.ReadUInt32();  // The offset to this object's vertex list.
+            uint PrimitiveCount       = reader.ReadUInt32();  // The amount of primatives specified in this object.
+            uint PrimitiveListOffset  = reader.ReadUInt32();  // The offset to this object's primitive list.
+            uint NodeCount            = reader.ReadUInt32();  // The amount of nodes that make up this object.
+            _NinjaObject.MaxNodeDepth = reader.ReadUInt32();  // The deepest level that a node is in a chain in this object.
+            uint NodeListOffset       = reader.ReadUInt32();  // The offset to this object's node list.
+            _NinjaObject.MatrixPAL    = reader.ReadUInt32();  // TODO: Figure out what this stands for and what it does. Matrix Something?
+            uint SubObjectCount       = reader.ReadUInt32();  // The amount of sub objects in this object.
+            uint SubObjectListOffset  = reader.ReadUInt32();  // The offset to this object's sub object list.
+            uint TextureCount         = reader.ReadUInt32();  // The amount of textures in this object (should just match up with the amount of entries in _NinjaTextureFileList?).
+
+            #region NNS_MATERIALPTR
+            // Jump to the object's material list.
+            reader.JumpTo(MaterialListOffset, true);
+
+            // Loop through based on amount of materials in this object's material list.
+            for (int i = 0; i < MaterialCount; i++)
+            {
+                NinjaObjectMaterial _NinjaObjectMaterial = new NinjaObjectMaterial();
+                _NinjaObjectMaterial.Type                = reader.ReadUInt32(); // This material's type.
+                uint MaterialDescriptionOffset           = reader.ReadUInt32(); // The offset to this material's NNS_MATERIAL_DESC chunk.
+                long position = reader.BaseStream.Position; // Save position so we can use it to jump back and read the next material after we've read all the data for this one.
+
+                // NNS_MATERIAL_DESC chunk
+                // Jump to this material's description chunk.
+                reader.JumpTo(MaterialDescriptionOffset, true);
+
+                _NinjaObjectMaterial.Description_Flag        = reader.ReadUInt32(); // The flags for this material.
+                _NinjaObjectMaterial.Description_UserDefined = reader.ReadUInt32(); // The user defined value for this material.
+                uint MaterialColourOffset                    = reader.ReadUInt32(); // The offset to this material's colour data.
+                uint MaterialLogicOffset                     = reader.ReadUInt32(); // The offset to this material's logic data.
+                uint MaterialTextureDescriptionOffset        = reader.ReadUInt32(); // The offset to this material's texture data.
+
+                // NNS_MATERIAL_COLOR chunk
+                if (MaterialColourOffset != 0)
+                {
+                    // Jump to this material's colour data.
+                    reader.JumpTo(MaterialColourOffset, true);
+
+                    _NinjaObjectMaterial.Colour_Diffuse  = reader.ReadVector4(); // The diffuse value for this material.
+                    _NinjaObjectMaterial.Colour_Ambient  = reader.ReadVector4(); // The ambient value for this material.
+                    _NinjaObjectMaterial.Colour_Specular = reader.ReadVector4(); // The specular value for this material.
+                    _NinjaObjectMaterial.Colour_Emissive = reader.ReadVector4(); // The diffuse value for this material.
+                    _NinjaObjectMaterial.Colour_Power    = reader.ReadSingle();  // How much the other values are affected? 
+                }
+
+                // NNS_MATERIAL_LOGIC chunk.
+                if (MaterialLogicOffset != 0)
+                {
+                    // Jump to this material's logic data.
+                    reader.JumpTo(MaterialLogicOffset, true);
+
+                    _NinjaObjectMaterial.Logic_BlendEnable   = reader.ReadBoolean32(); // Whether this material can do blending?
+                    _NinjaObjectMaterial.Logic_SRCBlend      = reader.ReadUInt32();
+                    _NinjaObjectMaterial.Logic_DSTBlend      = reader.ReadUInt32();
+                    _NinjaObjectMaterial.Logic_BlendFactor   = reader.ReadUInt32();    // Something to do with how much this material blends by?
+                    _NinjaObjectMaterial.Logic_BlendOP       = reader.ReadUInt32();
+                    _NinjaObjectMaterial.Logic_LogicOP       = reader.ReadUInt32();
+                    _NinjaObjectMaterial.Logic_AlphaEnable   = reader.ReadBoolean32(); // Whether this material supports alpha tranparency?
+                    _NinjaObjectMaterial.Logic_AlphaFunction = reader.ReadUInt32();
+                    _NinjaObjectMaterial.Logic_AlphaRef      = reader.ReadUInt32();    // How reflective the alpha channel is maybe?
+                    _NinjaObjectMaterial.Logic_ZCompEnable   = reader.ReadBoolean32();
+                    _NinjaObjectMaterial.Logic_ZFunction     = reader.ReadUInt32();
+                    _NinjaObjectMaterial.Logic_ZUpdateEnable = reader.ReadBoolean32();
+                }
+
+                // NNS_MATERIAL_TEXMAP2_DESC chunk.
+                if (MaterialTextureDescriptionOffset != 0)
+                {
+                    // Jump to this material's logic data.
+                    reader.JumpTo(MaterialTextureDescriptionOffset, true);
+
+                    _NinjaObjectMaterial.Texture_Type           = reader.ReadUInt32();
+                    _NinjaObjectMaterial.Texture_ID             = reader.ReadUInt32();  // Which texture in the _NinjaTextureFileList this material should use.
+                    _NinjaObjectMaterial.Texture_Offset         = reader.ReadVector2();
+                    _NinjaObjectMaterial.Texture_Blend          = reader.ReadSingle();
+                    uint TextureInfoOffset                      = reader.ReadUInt32();  // This is always null in '06's XNOs
+                    _NinjaObjectMaterial.Texture_MinFilter      = reader.ReadUInt32();
+                    _NinjaObjectMaterial.Texture_MagFilter      = reader.ReadUInt32();
+                    _NinjaObjectMaterial.Texture_MipMapBias     = reader.ReadSingle();
+                    _NinjaObjectMaterial.Texture_MaxMipMapLevel = reader.ReadUInt32();  // The highest level mipmap this material is allowed to use?
+                }
+
+                // Jump back to the saved position to read the next node.
+                reader.JumpTo(position);
+
+                // Save this material into the MaterialList in _NinjaObject.
+                _NinjaObject.MaterialList.Add(_NinjaObjectMaterial);
+            }
+            #endregion
+
+            #region NNS_VTXLISTPTR
+            // Jump to the object's vertex list.
+            reader.JumpTo(VertexListOffset, true);
+
+            // Loop through based on amount of verticies in this object's vertex list.
+            for (int i = 0; i < VertexCount; i++)
+            {
+                NinjaObjectVertex _NinjaObjectVertex = new NinjaObjectVertex();
+                _NinjaObjectVertex.Type              = reader.ReadUInt32(); // This vertex's type.
+                uint VertexDescriptionOffset         = reader.ReadUInt32(); // The offset to this vertex's NNS_VTXLIST_DX_DESC chunk..
+
+                long position = reader.BaseStream.Position; // Save position so we can use it to jump back and read the next vertex after we've read all the data for this one.
+
+                // NNS_VTXLIST_DX_DESC chunk
+                // Jump to this vertex's description chunk.
+                reader.JumpTo(VertexDescriptionOffset, true);
+
+                _NinjaObjectVertex.Description_Format    = reader.ReadUInt32(); // The format of this vertex.
+                _NinjaObjectVertex.Description_FVF       = reader.ReadUInt32();
+                uint VertexDataSize                      = reader.ReadUInt32(); // How many bytes each bit of data for this vertex takes up.
+                uint VertexDataCount                     = reader.ReadUInt32(); // How many bits of data make up this vertex.
+                uint VertexDataOffset                    = reader.ReadUInt32(); // The offset to this vertex's data.
+                uint BoneMatrixCount                     = reader.ReadUInt32(); // How any nodes makde up this vertex's bone matrix.
+                uint BoneMatrixOffset                    = reader.ReadUInt32(); // The offset to this vertex's bone matrix.
+                _NinjaObjectVertex.Description_HDRCommon = reader.ReadUInt32();
+                _NinjaObjectVertex.Description_HDRData   = reader.ReadUInt32();
+                _NinjaObjectVertex.Description_HDRLock   = reader.ReadUInt32();
+
+                // NNS_VTXTYPE_XB_??? Chunk.
+                if (VertexDataOffset != 0)
+                {
+                    // Jump to this vertex's data.
+                    reader.JumpTo(VertexDataOffset, true);
+                    for(int v = 0; v < VertexDataCount; v++)
+                    {
+                        long vertexPosition = reader.BaseStream.Position + VertexDataSize;
+                        NinjaObjectVertexXB _NinjaObjectVertexXB = new NinjaObjectVertexXB();
+
+                        // Position
+                        if ((_NinjaObjectVertex.Description_Format & 0x1) == 1){ _NinjaObjectVertexXB.List_Position = reader.ReadVector3(); }     
+
+                        // Weight
+                        if ((_NinjaObjectVertex.Description_Format & 0x7000) == 7000) { _NinjaObjectVertexXB.List_Weight = reader.ReadVector3(); }
+
+                        // Bone Matrix
+                        if ((_NinjaObjectVertex.Description_Format & 0x400) == 400)
+                        {
+                            _NinjaObjectVertexXB.List_BoneMatrix.Add(reader.ReadByte());
+                            _NinjaObjectVertexXB.List_BoneMatrix.Add(reader.ReadByte());
+                            _NinjaObjectVertexXB.List_BoneMatrix.Add(reader.ReadByte());
+                            _NinjaObjectVertexXB.List_BoneMatrix.Add(reader.ReadByte());
+                        }
+
+                        // Normals.
+                        if ((_NinjaObjectVertex.Description_Format & 0x2) == 2) { _NinjaObjectVertexXB.List_Normals = reader.ReadVector3(); } 
+
+                        // Vertex Colours
+                        if ((_NinjaObjectVertex.Description_Format & 0x8) == 8)
+                        {
+                            _NinjaObjectVertexXB.List_VertexColour.Add(reader.ReadByte());
+                            _NinjaObjectVertexXB.List_VertexColour.Add(reader.ReadByte());
+                            _NinjaObjectVertexXB.List_VertexColour.Add(reader.ReadByte());
+                            _NinjaObjectVertexXB.List_VertexColour.Add(reader.ReadByte());
+                        }
+
+                        // Texture Coordinates????.
+                        for(int t = 0; t < (_NinjaObjectVertex.Description_Format / 0x10000); t++)
+                        {
+                            _NinjaObjectVertexXB.List_TextureCoordinates.Add(reader.ReadVector2());
+                        }
+
+                        // Tangent and Binormals.
+                        if ((_NinjaObjectVertex.Description_Format & 0x140) == 140)
+                        {
+                            _NinjaObjectVertexXB.List_Tangent = reader.ReadVector3();
+                            _NinjaObjectVertexXB.List_Binormal = reader.ReadVector3();
+                        }
+
+                        // Save Vertex Entry.
+                        _NinjaObjectVertex.VertexList.Add(_NinjaObjectVertexXB);
+                        reader.JumpTo(vertexPosition);
+                    }
+                }
+
+                // nnbonematrixlist Chunk.
+                if (BoneMatrixOffset != 0)
+                {
+                    // Jump to this vertex's bone matrix.
+                    reader.JumpTo(BoneMatrixOffset, true);
+
+                    // Loop through based on amount of bones in this vertex's matrix and save them into the BoneMatrix in the _NinjaObjectVertex.
+                    for (int b = 0; b < BoneMatrixCount; b++)
+                        _NinjaObjectVertex.BoneMatrix.Add(reader.ReadInt32());
+                }
+
+                // Jump back to the saved position to read the next node.
+                reader.JumpTo(position);
+
+                // Save this vertex into the VertexList in _NinjaObject.
+                _NinjaObject.VertexList.Add(_NinjaObjectVertex);
+            }
+            #endregion
+
+            #region NNS_PRIMLISTPTR
+            // Jump to the object's primitive list.
+            reader.JumpTo(PrimitiveListOffset, true);
+
+            // Loop through based on amount of primitive in this object's primitive list.
+            for (int i = 0; i < PrimitiveCount; i++)
+            {
+                NinjaObjectPrimitive _NinjaObjectPrimitive = new NinjaObjectPrimitive();
+                _NinjaObjectPrimitive.Type                 = reader.ReadUInt32(); // This primitive's type.
+                uint PrimitiveStripListOffset              = reader.ReadUInt32(); // The offset to this primitive's NNS_PRIMTYPE_DX_STRIPLIST chunk.
+                long position = reader.BaseStream.Position; // Save position so we can use it to jump back and read the next primitive after we've read all the data for this one.
+
+                // NNS_PRIMTYPE_DX_STRIPLIST chunk.
+                // Jump to this primitive's strip list chunk.
+                reader.JumpTo(PrimitiveStripListOffset, true);
+
+                _NinjaObjectPrimitive.SList_Format = reader.ReadUInt32();
+                uint IndexNumber                   = reader.ReadUInt32();
+                uint StripCount                    = reader.ReadUInt32();
+                uint LengthOffset                  = reader.ReadUInt32();
+                uint IndexPointer                  = reader.ReadUInt32();
+                uint IDXBuffer                     = reader.ReadUInt32(); // Always 0?
+
+                // Jump to this primitive's length offset.
+                reader.JumpTo(LengthOffset, true);
+
+                ushort Length = reader.ReadUInt16();
+
+                // Jump to this primitive's index offset.
+                reader.JumpTo(IndexPointer, true);
+
+                // TODO: Figure out if I should be using IndexNumber or Length for this, the XTO always has SLIST_INDEX_NUM and the value in SLIST_LENPTR be the same, but other ones don't.
+                // Loop through based on amount of entries in this primitive's Strip List and save them into the SList_Index in the _NinjaObjectPrimitive.
+                for (int p = 0; p < IndexNumber; p++)
+                    _NinjaObjectPrimitive.SList_Index.Add(reader.ReadUInt16());
+
+                // Jump back to the saved position to read the next node.
+                reader.JumpTo(position);
+
+                // Save this primitive into the PrimitiveList in _NinjaObject.
+                _NinjaObject.PrimitiveList.Add(_NinjaObjectPrimitive);
+            }
+            #endregion
+
+            #region NNS_NODE
+            // Jump to the object's primitive list.
+            reader.JumpTo(NodeListOffset, true);
+
+            // Loop through based on amount of primitive in this object's primitive list.
+            for (int i = 0; i < NodeCount; i++)
+            {
+                NinjaObjectNode _NinjaObjectNode = new NinjaObjectNode();
+                _NinjaObjectNode.Type            = reader.ReadUInt32();  // This node's type.
+                _NinjaObjectNode.Matrix          = reader.ReadUInt16();  // This node's matrix reference, set to FFFF for NIL.
+                _NinjaObjectNode.Parent          = reader.ReadUInt16();  // This node's parent reference, set to FFFF for NIL.
+                _NinjaObjectNode.Child           = reader.ReadUInt16();  // This node's child reference, set to FFFF for NIL.
+                _NinjaObjectNode.Sibling         = reader.ReadUInt16();  // This node's sibling reference, set to FFFF for NIL.
+                _NinjaObjectNode.Transform       = reader.ReadVector3(); // This node's transform values.
+                _NinjaObjectNode.Rotation        = reader.ReadVector3(); // This node's rotation values.
+                _NinjaObjectNode.Scale           = reader.ReadVector3(); // This node's scale values.
+                _NinjaObjectNode.InvinitMatrix.Add(reader.ReadSingle());
+                _NinjaObjectNode.InvinitMatrix.Add(reader.ReadSingle());
+                _NinjaObjectNode.InvinitMatrix.Add(reader.ReadSingle());
+                _NinjaObjectNode.InvinitMatrix.Add(reader.ReadSingle());
+                _NinjaObjectNode.InvinitMatrix.Add(reader.ReadSingle());
+                _NinjaObjectNode.InvinitMatrix.Add(reader.ReadSingle());
+                _NinjaObjectNode.InvinitMatrix.Add(reader.ReadSingle());
+                _NinjaObjectNode.InvinitMatrix.Add(reader.ReadSingle());
+                _NinjaObjectNode.InvinitMatrix.Add(reader.ReadSingle());
+                _NinjaObjectNode.InvinitMatrix.Add(reader.ReadSingle());
+                _NinjaObjectNode.InvinitMatrix.Add(reader.ReadSingle());
+                _NinjaObjectNode.InvinitMatrix.Add(reader.ReadSingle());
+                _NinjaObjectNode.InvinitMatrix.Add(reader.ReadSingle());
+                _NinjaObjectNode.InvinitMatrix.Add(reader.ReadSingle());
+                _NinjaObjectNode.InvinitMatrix.Add(reader.ReadSingle());
+                _NinjaObjectNode.InvinitMatrix.Add(reader.ReadSingle());
+                _NinjaObjectNode.Center          = reader.ReadVector3(); // The central point of this node.
+                _NinjaObjectNode.Radius          = reader.ReadSingle();  // The radius of this node.
+                _NinjaObjectNode.UserDefined     = reader.ReadUInt32();  // This node's user defined data.
+                _NinjaObjectNode.BoundingBox     = reader.ReadVector3(); // This node's bounding box/reserved data.
+
+                // Save this node into the NodeList in _NinjaObject.
+                _NinjaObject.NodeList.Add(_NinjaObjectNode);
+            }
+            #endregion
+
+            #region NNS_SUBOBJ
+            // Jump to the object's sub object list.
+            reader.JumpTo(SubObjectListOffset, true);
+
+            // Loop through based on amount of sub objects in this object's sub object list.
+            for (int i = 0; i < SubObjectCount; i++)
+            {
+                NinjaSubObject _NinjaSubObject  = new NinjaSubObject();
+                _NinjaSubObject.Type            = reader.ReadUInt32(); // This sub object's type.
+                uint MeshSetCount               = reader.ReadUInt32();
+                uint MeshSetOffset              = reader.ReadUInt32();
+                uint SubObjectTextureCount      = reader.ReadUInt32();
+                uint SubObjectTextureListOffset = reader.ReadUInt32();
+                long position = reader.BaseStream.Position; // Save position so we can use it to jump back and read the next sub object after we've read all the data for this one.
+
+                // NNS_MESHSET Chunk.
+                // Jump to this sub object's mesh set data.
+                reader.JumpTo(MeshSetOffset, true);
+
+                for(int m = 0; m < MeshSetCount; m++)
+                {
+                    NinjaSubObjectMeshSet _NinjaSubObjectMeshSet = new NinjaSubObjectMeshSet
+                    {
+                        Center      = reader.ReadVector3(),
+                        Radius      = reader.ReadSingle(),
+                        NodeID      = reader.ReadUInt32(),
+                        Matrix      = reader.ReadUInt32(),
+                        MaterialID  = reader.ReadUInt32(),
+                        VertexID    = reader.ReadUInt32(),
+                        PrimitiveID = reader.ReadUInt32(),
+                        ShaderID    = reader.ReadUInt32()
+                    };
+                    _NinjaSubObject.MeshSets.Add(_NinjaSubObjectMeshSet);
+                }
+
+                // Jump to this sub object's texture list offset.
+                reader.JumpTo(SubObjectTextureListOffset, true);
+
+                // Loop through based on amount of entries in this sub object's Texture List and save them into the TextureList in the _NinjaSubObject.
+                for (int t = 0; t < SubObjectTextureCount; t++)
+                    _NinjaSubObject.TextureList.Add(reader.ReadInt32());
+
+                // Jump back to the saved position to read the next node.
+                reader.JumpTo(position);
+
+                // Save this sub object into the SubObjectList in _NinjaObject.
+                _NinjaObject.SubObjectList.Add(_NinjaSubObject);
+            }
+            #endregion
+
+            // Return to the previously saved position and jump ahead by NodeLength to place us at the next node.
+            reader.JumpTo(returnPosition);
+            reader.JumpAhead(NodeLength);
+        }
+
+        public void ReadNinjaMotion(ExtendedBinaryReader reader)
+        {
+            // Create the _NinjaMotion so we can write to it.
+            _NinjaMotion = new NinjaMotion();
+
+            string MotionNodeType = new string(reader.ReadChars(4)); // The type of this Motion Node.
+            uint NodeLength       = reader.ReadUInt32();             // The length of this Node.
+            long returnPosition   = reader.BaseStream.Position;      // Save position so we can use it with the length to jump to the next Node afterwards.
+            uint NodeOffset       = reader.ReadUInt32();             // Where this Node's Data starts.
+
+            // Jump to the motion node's data.
+            reader.JumpTo(NodeOffset, true);
+
+            _NinjaMotion.Type        = reader.ReadUInt32();
+            _NinjaMotion.StartFrame  = reader.ReadSingle();
+            _NinjaMotion.EndFrame    = reader.ReadSingle();
+            uint SubMotionCount      = reader.ReadUInt32();
+            uint SubMotionListOffset = reader.ReadUInt32();
+            _NinjaMotion.Framerate   = reader.ReadSingle();
+            _NinjaMotion.Reserved0   = reader.ReadUInt32();
+            _NinjaMotion.Reserved1   = reader.ReadUInt32();
+
+            // Sub Motions
+            reader.JumpTo(SubMotionListOffset, true);
+            for(int i = 0; i < SubMotionCount; i++)
+            {
+                NinjaSubMotion _NinjaSubMotion    = new NinjaSubMotion();
+                _NinjaSubMotion.SubMot_Type       = reader.ReadUInt32();  // This value is needed to figure out what the data should be read as. Is all in S06XnFile.h in LibS06
+                _NinjaSubMotion.SubMot_IPType     = reader.ReadUInt32();
+                _NinjaSubMotion.SubMot_ID         = reader.ReadUInt32();
+                _NinjaSubMotion.SubMot_StartFrame = reader.ReadSingle();
+                _NinjaSubMotion.SubMot_EndFrame   = reader.ReadSingle();
+                _NinjaSubMotion.SubMot_StartKey   = reader.ReadSingle();
+                _NinjaSubMotion.SubMot_EndKey     = reader.ReadSingle();
+                uint KeyFrameCount                = reader.ReadUInt32();
+                uint KeySize                      = reader.ReadUInt32();
+                uint KeyOffset                    = reader.ReadUInt32();
+
+                // Store current position to jump back to for the next sub motion.
+                long position = reader.BaseStream.Position;
+
+                // Keys
+                reader.JumpTo(KeyOffset, true);
+                for(int k = 0; k < KeyFrameCount; k++)
+                {
+                    NinjaSubMotionKey _NinjaSubMotionKey = new NinjaSubMotionKey();
+                    switch (_NinjaSubMotion.SubMot_Type)
+                    {
+                        case 257:
+                        case 513:
+                        case 1025:
+                        case 16777217:
+                            _NinjaSubMotionKey.Key_Translation_MFRM = reader.ReadSingle();
+                            _NinjaSubMotionKey.Key_Translation_MVAL = reader.ReadSingle();
+                            _NinjaSubMotion.SubMot_KeyList.Add(_NinjaSubMotionKey);
+                            break;
+                        case 2066:
+                        case 4114:
+                        case 8210:
+                            _NinjaSubMotionKey.Key_Rotation_MFRM = reader.ReadInt16();
+                            _NinjaSubMotionKey.Key_Rotation_MVAL = reader.ReadHalf();
+                            _NinjaSubMotion.SubMot_KeyList.Add(_NinjaSubMotionKey);
+                            break;
+                        case 3585:
+                            _NinjaSubMotionKey.Key_Diffuse_MFRM = reader.ReadSingle();
+                            _NinjaSubMotionKey.Key_Diffuse_MVAL = reader.ReadVector3();
+                            _NinjaSubMotion.SubMot_KeyList.Add(_NinjaSubMotionKey);
+                            break;
+                        default:
+                            Console.WriteLine($"NinjaSubMotion Type of 0x{_NinjaSubMotion.SubMot_Type.ToString("X").PadLeft(8, '0')} ({_NinjaSubMotion.SubMot_Type}) not currently supported!");
+                            break;
+                    }
+                }
+
+                // Jump back to the saved position to read the next sub motion.
+                reader.JumpTo(position);
+
+                _NinjaMotion.SubMotions.Add(_NinjaSubMotion);
+            }
+
+            // Return to the previously saved position and jump ahead by NodeLength to place us at the next node.
+            reader.JumpTo(returnPosition);
+            reader.JumpAhead(NodeLength);
+        }
+    }
+}

--- a/Marathon.IO/Formats/Miscellaneous/AssetPackage.cs
+++ b/Marathon.IO/Formats/Miscellaneous/AssetPackage.cs
@@ -38,6 +38,19 @@ namespace Marathon.IO.Formats.Miscellaneous
     /// </summary>
     public class AssetPackage : FileBase
     {
+        public AssetPackage(string file)
+        {
+            switch (Path.GetExtension(file))
+            {
+                case ".xml":
+                    ImportXML(file);
+                    break;
+                default:
+                    Load(file);
+                    break;
+            }
+        }
+
         public class TypeEntry
         {
             public string TypeName;

--- a/Marathon.IO/Formats/Miscellaneous/AssetPackage.cs
+++ b/Marathon.IO/Formats/Miscellaneous/AssetPackage.cs
@@ -38,6 +38,7 @@ namespace Marathon.IO.Formats.Miscellaneous
     /// </summary>
     public class AssetPackage : FileBase
     {
+        public AssetPackage() { }
         public AssetPackage(string file)
         {
             switch (Path.GetExtension(file))

--- a/Marathon.IO/Formats/Miscellaneous/CommonPackage.cs
+++ b/Marathon.IO/Formats/Miscellaneous/CommonPackage.cs
@@ -38,6 +38,8 @@ namespace Marathon.IO.Formats.Miscellaneous
     public class CommonPackage : FileBase
     {
         // TODO: Understand the unknown values.
+
+        public CommonPackage() { }
         public CommonPackage(string file)
         {
             switch (Path.GetExtension(file))

--- a/Marathon.IO/Formats/Miscellaneous/CommonPackage.cs
+++ b/Marathon.IO/Formats/Miscellaneous/CommonPackage.cs
@@ -38,6 +38,19 @@ namespace Marathon.IO.Formats.Miscellaneous
     public class CommonPackage : FileBase
     {
         // TODO: Understand the unknown values.
+        public CommonPackage(string file)
+        {
+            switch (Path.GetExtension(file))
+            {
+                case ".xml":
+                    ImportXML(file);
+                    break;
+                default:
+                    Load(file);
+                    break;
+            }
+        }
+
         public class ObjectEntry
         {
             public string PropName,

--- a/Marathon.IO/Formats/Miscellaneous/EventPlaybook.cs
+++ b/Marathon.IO/Formats/Miscellaneous/EventPlaybook.cs
@@ -38,6 +38,7 @@ namespace Marathon.IO.Formats.Miscellaneous
     /// </summary>
     public class EventPlaybook : FileBase
     {
+        public EventPlaybook() { }
         public EventPlaybook(string file)
         {
             switch (Path.GetExtension(file))

--- a/Marathon.IO/Formats/Miscellaneous/EventPlaybook.cs
+++ b/Marathon.IO/Formats/Miscellaneous/EventPlaybook.cs
@@ -38,6 +38,19 @@ namespace Marathon.IO.Formats.Miscellaneous
     /// </summary>
     public class EventPlaybook : FileBase
     {
+        public EventPlaybook(string file)
+        {
+            switch (Path.GetExtension(file))
+            {
+                case ".xml":
+                    ImportXML(file);
+                    break;
+                default:
+                    Load(file);
+                    break;
+            }
+        }
+
         public class Event
         {
             public string Name,
@@ -227,14 +240,14 @@ namespace Marathon.IO.Formats.Miscellaneous
                 // Read event values.
                 Event @event = new Event
                 {
-                    Name = eventElem.Element("Name").Value,
-                    Folder = eventElem.Element("Folder").Value,
-                    EventLength = uint.Parse(eventElem.Element("EventLength").Value),
-                    Terrain = eventElem.Element("Terrain").Value,
-                    SceneLua = eventElem.Element("SceneLua").Value,
-                    SceneBank = eventElem.Element("SceneBank").Value,
+                    Name         = eventElem.Element("Name").Value,
+                    Folder       = eventElem.Element("Folder").Value,
+                    EventLength  = uint.Parse(eventElem.Element("EventLength").Value),
+                    Terrain      = eventElem.Element("Terrain").Value,
+                    SceneLua     = eventElem.Element("SceneLua").Value,
+                    SceneBank    = eventElem.Element("SceneBank").Value,
                     ParticleList = eventElem.Element("ParticleList").Value,
-                    SubtitleMST = eventElem.Element("SubtitleMST").Value
+                    SubtitleMST  = eventElem.Element("SubtitleMST").Value
                 };
 
                 // Position

--- a/Marathon.IO/Formats/Miscellaneous/ExplosionPackage.cs
+++ b/Marathon.IO/Formats/Miscellaneous/ExplosionPackage.cs
@@ -12,6 +12,8 @@ namespace Marathon.IO.Formats.Miscellaneous
     public class ExplosionPackage : FileBase
     {
         // TODO: Understand the unknowns, clean up code.
+
+        public ExplosionPackage() { }
         public ExplosionPackage(string file)
         {
             switch (Path.GetExtension(file))

--- a/Marathon.IO/Formats/Miscellaneous/ExplosionPackage.cs
+++ b/Marathon.IO/Formats/Miscellaneous/ExplosionPackage.cs
@@ -12,19 +12,31 @@ namespace Marathon.IO.Formats.Miscellaneous
     public class ExplosionPackage : FileBase
     {
         // TODO: Understand the unknowns, clean up code.
+        public ExplosionPackage(string file)
+        {
+            switch (Path.GetExtension(file))
+            {
+                case ".xml":
+                    ImportXML(file);
+                    break;
+                default:
+                    Load(file);
+                    break;
+            }
+        }
 
         public class Entry
         {
             public string EntryName;
             public uint UnknownUInt32_1; // Setting this to 1 allowed a BombBox explosion to take enemies out, 0 & 2 didn't.
-            public float Radius; // The radius that this explosion affects
+            public float Radius;         // The radius that this explosion affects
             public float UnknownFloat_1; // Nearly always the same as Radius, barring a few exceptions.
             public float UnknownFloat_2;
             public float UnknownFloat_3;
             public float UnknownFloat_4;
-            public float Force; //Not too sure, but increasing this value seemed to affect something to do with how the explosion affects other physics objects?
-            public uint Damage; // How much damage this explosion causes.
-            public uint Behaviour; // How things should react to this explosion? Has a lot of different values, 46 made every explosion stun enemies like a FlashBox and be unable to damage the player.
+            public float Force;          //Not too sure, but increasing this value seemed to affect something to do with how the explosion affects other physics objects?
+            public uint Damage;          // How much damage this explosion causes.
+            public uint Behaviour;       // How things should react to this explosion? Has a lot of different values, 46 made every explosion stun enemies like a FlashBox and be unable to damage the player.
             public string ParticleFile;
             public string ParticleName;
             public string SceneBank;
@@ -52,21 +64,21 @@ namespace Marathon.IO.Formats.Miscellaneous
             {
                 Entry explosion = new Entry();
 
-                uint nameOffset = reader.ReadUInt32();
+                uint nameOffset           = reader.ReadUInt32();
                 explosion.UnknownUInt32_1 = reader.ReadUInt32();
-                explosion.Radius = reader.ReadSingle();
-                explosion.UnknownFloat_1 = reader.ReadSingle();
-                explosion.UnknownFloat_2 = reader.ReadSingle();
-                explosion.UnknownFloat_3 = reader.ReadSingle();
-                explosion.UnknownFloat_4 = reader.ReadSingle();
-                explosion.Force = reader.ReadSingle();
-                explosion.Damage = reader.ReadUInt32();
-                explosion.Behaviour = reader.ReadUInt32();
-                uint particleFileOffset = reader.ReadUInt32();
-                uint particleNameOffset = reader.ReadUInt32();
-                uint SceneBankOffset = reader.ReadUInt32();
-                uint soundNameOffset = reader.ReadUInt32();
-                uint lightNameOffset = reader.ReadUInt32();
+                explosion.Radius          = reader.ReadSingle();
+                explosion.UnknownFloat_1  = reader.ReadSingle();
+                explosion.UnknownFloat_2  = reader.ReadSingle();
+                explosion.UnknownFloat_3  = reader.ReadSingle();
+                explosion.UnknownFloat_4  = reader.ReadSingle();
+                explosion.Force           = reader.ReadSingle();
+                explosion.Damage          = reader.ReadUInt32();
+                explosion.Behaviour       = reader.ReadUInt32();
+                uint particleFileOffset   = reader.ReadUInt32();
+                uint particleNameOffset   = reader.ReadUInt32();
+                uint SceneBankOffset      = reader.ReadUInt32();
+                uint soundNameOffset      = reader.ReadUInt32();
+                uint lightNameOffset      = reader.ReadUInt32();
 
                 reader.JumpAhead(12); //Padding? All nulls in official file. Might be worth experimenting with to see if anything changes.
                 long position = reader.BaseStream.Position;
@@ -136,23 +148,23 @@ namespace Marathon.IO.Formats.Miscellaneous
             foreach (Entry explosion in Entries)
             {
                 XElement explosionElem = new XElement("Explosion");
-                XAttribute NameAttr = new XAttribute("ObjectName", explosion.EntryName);
-                XElement UInt1Elem = new XElement("UnknownUInt32_1", explosion.UnknownUInt32_1);
-                XElement Float1Elem = new XElement("Radius", explosion.Radius);
-                XElement Float2Elem = new XElement("UnknownFloat_1", explosion.UnknownFloat_1);
-                XElement Float3Elem = new XElement("UnknownFloat_2", explosion.UnknownFloat_2);
-                XElement Float4Elem = new XElement("UnknownFloat_3", explosion.UnknownFloat_3);
-                XElement Float5Elem = new XElement("UnknownFloat_4", explosion.UnknownFloat_4);
-                XElement Float6Elem = new XElement("Force", explosion.Force);
-                XElement UInt2Elem = new XElement("Damage", explosion.Damage);
-                XElement UInt3Elem = new XElement("Behaviour", explosion.Behaviour);
+                XAttribute NameAttr    = new XAttribute("ObjectName", explosion.EntryName);
+                XElement UInt1Elem     = new XElement("UnknownUInt32_1", explosion.UnknownUInt32_1);
+                XElement Float1Elem    = new XElement("Radius", explosion.Radius);
+                XElement Float2Elem    = new XElement("UnknownFloat_1", explosion.UnknownFloat_1);
+                XElement Float3Elem    = new XElement("UnknownFloat_2", explosion.UnknownFloat_2);
+                XElement Float4Elem    = new XElement("UnknownFloat_3", explosion.UnknownFloat_3);
+                XElement Float5Elem    = new XElement("UnknownFloat_4", explosion.UnknownFloat_4);
+                XElement Float6Elem    = new XElement("Force", explosion.Force);
+                XElement UInt2Elem     = new XElement("Damage", explosion.Damage);
+                XElement UInt3Elem     = new XElement("Behaviour", explosion.Behaviour);
 
                 XAttribute ParticleBankAttr = new XAttribute("ParticleBank", explosion.ParticleFile);
-                XElement ParticleElem = new XElement("Particle", explosion.ParticleName);
+                XElement ParticleElem       = new XElement("Particle", explosion.ParticleName);
                 ParticleElem.Add(ParticleBankAttr);
 
                 XAttribute SceneBankAttr = new XAttribute("SceneBank", explosion.SceneBank);
-                XElement SoundElem = new XElement("Sound", explosion.SoundName);
+                XElement SoundElem       = new XElement("Sound", explosion.SoundName);
                 SoundElem.Add(SceneBankAttr);
 
                 XElement LightElem = new XElement("Light", explosion.LightName);
@@ -177,21 +189,21 @@ namespace Marathon.IO.Formats.Miscellaneous
                 // Read explosion values.
                 Entry entry = new Entry
                 {
-                    EntryName = explosionElem.Attribute("ObjectName").Value,
+                    EntryName       = explosionElem.Attribute("ObjectName").Value,
                     UnknownUInt32_1 = uint.Parse(explosionElem.Element("UnknownUInt32_1").Value),
-                    Radius = float.Parse(explosionElem.Element("Radius").Value),
-                    UnknownFloat_1 = float.Parse(explosionElem.Element("UnknownFloat_1").Value),
-                    UnknownFloat_2 = float.Parse(explosionElem.Element("UnknownFloat_2").Value),
-                    UnknownFloat_3 = float.Parse(explosionElem.Element("UnknownFloat_3").Value),
-                    UnknownFloat_4 = float.Parse(explosionElem.Element("UnknownFloat_4").Value),
-                    Force = float.Parse(explosionElem.Element("Force").Value),
-                    Damage = uint.Parse(explosionElem.Element("Damage").Value),
-                    Behaviour = uint.Parse(explosionElem.Element("Behaviour").Value),
-                    ParticleFile = explosionElem.Element("Particle").Attribute("ParticleBank").Value,
-                    ParticleName = explosionElem.Element("Particle").Value,
-                    SceneBank = explosionElem.Element("Sound").Attribute("SceneBank").Value,
-                    SoundName = explosionElem.Element("Sound").Value,
-                    LightName = explosionElem.Element("Light").Value
+                    Radius          = float.Parse(explosionElem.Element("Radius").Value),
+                    UnknownFloat_1  = float.Parse(explosionElem.Element("UnknownFloat_1").Value),
+                    UnknownFloat_2  = float.Parse(explosionElem.Element("UnknownFloat_2").Value),
+                    UnknownFloat_3  = float.Parse(explosionElem.Element("UnknownFloat_3").Value),
+                    UnknownFloat_4  = float.Parse(explosionElem.Element("UnknownFloat_4").Value),
+                    Force           = float.Parse(explosionElem.Element("Force").Value),
+                    Damage          = uint.Parse(explosionElem.Element("Damage").Value),
+                    Behaviour       = uint.Parse(explosionElem.Element("Behaviour").Value),
+                    ParticleFile    = explosionElem.Element("Particle").Attribute("ParticleBank").Value,
+                    ParticleName    = explosionElem.Element("Particle").Value,
+                    SceneBank       = explosionElem.Element("Sound").Attribute("SceneBank").Value,
+                    SoundName       = explosionElem.Element("Sound").Value,
+                    LightName       = explosionElem.Element("Light").Value
                 };
 
                 // Add object to Entries list.

--- a/Marathon.IO/Formats/Miscellaneous/ObjectPropertyDatabase.cs
+++ b/Marathon.IO/Formats/Miscellaneous/ObjectPropertyDatabase.cs
@@ -37,6 +37,7 @@ namespace Marathon.IO.Formats.Miscellaneous
     /// </summary>
     public class ObjectPropertyDatabase : FileBase
     {
+        public ObjectPropertyDatabase() { }
         public ObjectPropertyDatabase(string file)
         {
             switch (Path.GetExtension(file))

--- a/Marathon.IO/Formats/Miscellaneous/ObjectPropertyDatabase.cs
+++ b/Marathon.IO/Formats/Miscellaneous/ObjectPropertyDatabase.cs
@@ -37,6 +37,19 @@ namespace Marathon.IO.Formats.Miscellaneous
     /// </summary>
     public class ObjectPropertyDatabase : FileBase
     {
+        public ObjectPropertyDatabase(string file)
+        {
+            switch (Path.GetExtension(file))
+            {
+                case ".xml":
+                    ImportXML(file);
+                    break;
+                default:
+                    Load(file);
+                    break;
+            }
+        }
+
         public class Entry
         {
             public string Name;
@@ -68,8 +81,8 @@ namespace Marathon.IO.Formats.Miscellaneous
             {
                 Entry entry = new Entry();
                 uint objectNameOffset = reader.ReadUInt32();
-                uint parameterCount = reader.ReadUInt32();
-                uint parameterOffset = reader.ReadUInt32();
+                uint parameterCount   = reader.ReadUInt32();
+                uint parameterOffset  = reader.ReadUInt32();
 
                 reader.JumpAhead(8); // Always 0.
 

--- a/Marathon.IO/Formats/Miscellaneous/PathPackage.cs
+++ b/Marathon.IO/Formats/Miscellaneous/PathPackage.cs
@@ -38,6 +38,7 @@ namespace Marathon.IO.Formats.Miscellaneous
     {
         // TODO: Write XML Exporter and Importer.
 
+        public PathPackage() { }
         public PathPackage(string file)
         {
             switch (Path.GetExtension(file))

--- a/Marathon.IO/Formats/Miscellaneous/PathPackage.cs
+++ b/Marathon.IO/Formats/Miscellaneous/PathPackage.cs
@@ -36,6 +36,21 @@ namespace Marathon.IO.Formats.Miscellaneous
     /// </summary>
     public class PathPackage : FileBase
     {
+        // TODO: Write XML Exporter and Importer.
+
+        public PathPackage(string file)
+        {
+            switch (Path.GetExtension(file))
+            {
+                case ".xml":
+                    //ImportXML(file);
+                    break;
+                default:
+                    Load(file);
+                    break;
+            }
+        }
+
         public class ObjectEntry
         {
             public string Name;

--- a/Marathon.IO/Formats/Miscellaneous/PathSpline.cs
+++ b/Marathon.IO/Formats/Miscellaneous/PathSpline.cs
@@ -39,6 +39,18 @@ namespace Marathon.IO.Formats.Miscellaneous
     ///
     public class PathSpline : FileBase
     {
+        // TODO: Exporting and Importing, Testing to understand what the flags and Invec/Outvec Positions effect, So Basically Everything.
+
+        public PathSpline(string file)
+        {
+            switch (Path.GetExtension(file))
+            {
+                default:
+                    Load(file);
+                    break;
+            }
+        }
+
         public class PathEntry
         {
             public uint Flag1, Flag2, NodeNumber;
@@ -60,8 +72,6 @@ namespace Marathon.IO.Formats.Miscellaneous
         public const string Extension = ".path";
 
         public List<PathEntry> Paths = new List<PathEntry>();
-
-        // TODO: Exporting and Importing, Testing to understand what the flags and Invec/Outvec Positions effect, So Basically Everything.
 
         public override void Load(Stream stream)
         {

--- a/Marathon.IO/Formats/Miscellaneous/PathSpline.cs
+++ b/Marathon.IO/Formats/Miscellaneous/PathSpline.cs
@@ -80,9 +80,9 @@ namespace Marathon.IO.Formats.Miscellaneous
             reader.ReadHeader();
 
             uint PathTableOffset = reader.ReadUInt32(); // Where the table of paths is.
-            uint PathTableCount = reader.ReadUInt32();  // How many entries are in the table of paths.
+            uint PathTableCount  = reader.ReadUInt32(); // How many entries are in the table of paths.
             uint NodeTableOffset = reader.ReadUInt32(); // Where the table of nodes is.
-            uint NodeTableCount = reader.ReadUInt32();  // How many enteries are in the table of nodes, seems to always be the same as PathTableCount?
+            uint NodeTableCount  = reader.ReadUInt32(); // How many enteries are in the table of nodes, seems to always be the same as PathTableCount?
 
             // Jump to the Path Table's Offset for safety's sake, should always be ox30 really.
             reader.JumpTo(PathTableOffset, true);
@@ -90,10 +90,10 @@ namespace Marathon.IO.Formats.Miscellaneous
             // Loop through based on PathTableCount.
             for (int i = 0; i < PathTableCount; i++)
             {
-                PathEntry path = new PathEntry();
-                uint PathOffset = reader.ReadUInt32();  // Offset to the path data.
+                PathEntry path   = new PathEntry();
+                uint PathOffset  = reader.ReadUInt32(); // Offset to the path data.
                 uint SplineCount = reader.ReadUInt32(); // How many splines make up this path.
-                path.Flag1 = reader.ReadUInt32();       // Read this path's flag.
+                path.Flag1       = reader.ReadUInt32(); // Read this path's flag.
 
                 // Store position in file.
                 long position = reader.BaseStream.Position;
@@ -102,8 +102,8 @@ namespace Marathon.IO.Formats.Miscellaneous
                 reader.JumpTo(PathOffset, true);
 
                 uint SplineOffset = reader.ReadUInt32(); // Offset to the spines of this path.
-                uint VertexCount = reader.ReadUInt32();  // How many verticies make up this path's splines.
-                path.Flag2 = reader.ReadUInt32();        // Read this path's second flag.
+                uint VertexCount  = reader.ReadUInt32(); // How many verticies make up this path's splines.
+                path.Flag2        = reader.ReadUInt32(); // Read this path's second flag.
 
                 // Jump to the position of this path's splines.
                 reader.JumpTo(SplineOffset, true);
@@ -116,9 +116,9 @@ namespace Marathon.IO.Formats.Miscellaneous
                     {
                         VertexEntry vertex = new VertexEntry
                         {
-                            Flag = reader.ReadUInt32(),
-                            Position = reader.ReadVector3(),
-                            InvecPosition = reader.ReadVector3(),
+                            Flag           = reader.ReadUInt32(),
+                            Position       = reader.ReadVector3(),
+                            InvecPosition  = reader.ReadVector3(),
                             OutvecPosition = reader.ReadVector3()
                         };
                         spline.Verticies.Add(vertex);
@@ -138,8 +138,8 @@ namespace Marathon.IO.Formats.Miscellaneous
             for (int i = 0; i < NodeTableCount; i++)
             {
                 Paths[i].NodeNumber = reader.ReadUInt32();    // Unknown, usually the same as the path's number sequentially, but not always.
-                Paths[i].Position = reader.ReadVector3();
-                Paths[i].Rotation = reader.ReadQuaternion();
+                Paths[i].Position   = reader.ReadVector3();
+                Paths[i].Rotation   = reader.ReadQuaternion();
                 uint NameOffset = reader.ReadUInt32();       // Offset to the path's name.
 
                 // Store position in file.

--- a/Marathon.IO/Formats/Miscellaneous/PathSpline.cs
+++ b/Marathon.IO/Formats/Miscellaneous/PathSpline.cs
@@ -41,6 +41,7 @@ namespace Marathon.IO.Formats.Miscellaneous
     {
         // TODO: Exporting and Importing, Testing to understand what the flags and Invec/Outvec Positions effect, So Basically Everything.
 
+        public PathSpline() { }
         public PathSpline(string file)
         {
             switch (Path.GetExtension(file))

--- a/Marathon.IO/Formats/Miscellaneous/SonicNextSaveData.cs
+++ b/Marathon.IO/Formats/Miscellaneous/SonicNextSaveData.cs
@@ -82,9 +82,7 @@ namespace Marathon.IO.Formats.Miscellaneous
     /// </summary>
     public class SonicNextSaveData : FixedFileBase
     {
-        /// <summary>
-        /// Information stored for each episode.
-        /// </summary>
+        public SonicNextSaveData() { }
         public SonicNextSaveData(string file)
         {
             switch (Path.GetExtension(file))
@@ -94,6 +92,10 @@ namespace Marathon.IO.Formats.Miscellaneous
                     break;
             }
         }
+
+        /// <summary>
+        /// Information stored for each episode.
+        /// </summary>
 
         public class Episode
         {

--- a/Marathon.IO/Formats/Miscellaneous/SonicNextSaveData.cs
+++ b/Marathon.IO/Formats/Miscellaneous/SonicNextSaveData.cs
@@ -85,6 +85,16 @@ namespace Marathon.IO.Formats.Miscellaneous
         /// <summary>
         /// Information stored for each episode.
         /// </summary>
+        public SonicNextSaveData(string file)
+        {
+            switch (Path.GetExtension(file))
+            {
+                default:
+                    Load(file);
+                    break;
+            }
+        }
+
         public class Episode
         {
             public long Offset;     // Offset of the current episode.

--- a/Marathon.IO/Formats/Miscellaneous/TimeEvent.cs
+++ b/Marathon.IO/Formats/Miscellaneous/TimeEvent.cs
@@ -1,0 +1,161 @@
+﻿using System.IO;
+using System.Xml.Linq;
+using System.Collections.Generic;
+using Marathon.IO.Headers;
+using Marathon.IO.Exceptions;
+
+namespace Marathon.IO.Formats.Miscellaneous
+{
+    public class TimeEvent : FileBase
+    {
+        // TODO: Experiment with the values. Cleanup Code.
+        public class Entry
+        {
+            public string TargetNode;
+            public string ParticleBank;
+            public string Particle;
+            public Vector2 UnknownVector2_1; // These values seem to always be 1 off each other, not sure if they should be decoupled or not.
+            public bool UnknownBoolean_1;
+            public Vector3 ParticlePosition;
+            public Vector3 UnknownVector3_2;
+        }
+
+        public string XNM;
+        public List<Entry> Entries = new List<Entry>();
+
+        public const string Signature = ".TEV", Extension = ".tev";
+        public override void Load(Stream fileStream)
+        {
+            BINAReader reader = new BINAReader(fileStream);
+            reader.ReadHeader();
+
+            string signature = reader.ReadSignature(4);
+            if (signature != Signature) throw new InvalidSignatureException(Signature, signature);
+
+            reader.JumpAhead(4); // Always null in official files.
+            uint XNMOffset = reader.ReadUInt32();
+
+            // Read XNM associated with this time event file.            
+            long position = reader.BaseStream.Position; // Save poision so we can jump back.
+            reader.JumpTo(XNMOffset, true);             // Jump to XNMOffset.
+            XNM = reader.ReadNullTerminatedString();    // Read XNM string.
+            reader.JumpTo(position);                    // Return to previous position.
+
+            uint EntryCount       = reader.ReadUInt32();
+            uint EventTableOffset = reader.ReadUInt32(); // Offset to the table of entries in this time event file..
+
+            // Jump to the Event Table's Offset for safety's sake, should always be ox20 really.
+            reader.JumpTo(EventTableOffset, true);
+
+            // Loop through entries
+            for (int i = 0; i < EntryCount; i++)
+            {
+                Entry entry = new Entry();
+
+                reader.JumpAhead(4); // Always null in official files.
+                uint TargetNodeOffset   = reader.ReadUInt32();
+                uint ParticleBankOffset = reader.ReadUInt32();
+                uint ParticleOffset     = reader.ReadUInt32();
+                entry.UnknownVector2_1  = reader.ReadVector2();
+                reader.JumpAhead(1); // Always null in official files. Padding?
+                entry.UnknownBoolean_1 = reader.ReadBoolean();
+                reader.JumpAhead(2); // Always null in official files. Padding?
+                entry.ParticlePosition  = reader.ReadVector3();
+                entry.UnknownVector3_2  = reader.ReadVector3();
+
+                // Store current position to jump back to for the next entry.
+                position = reader.BaseStream.Position;
+
+                reader.JumpTo(TargetNodeOffset, true);
+                entry.TargetNode = reader.ReadNullTerminatedString();
+
+                reader.JumpTo(ParticleBankOffset, true);
+                entry.ParticleBank = reader.ReadNullTerminatedString();
+
+                reader.JumpTo(ParticleOffset, true);
+                entry.Particle = reader.ReadNullTerminatedString();
+
+                // Jump back to the saved position to read the next entry..
+                reader.JumpTo(position);
+
+                // Save event entry into the Entries list.
+                Entries.Add(entry);
+            }
+        }
+
+        public override void Save(Stream fileStream)
+        {
+            BINAv1Header Header = new BINAv1Header();
+            BINAWriter writer = new BINAWriter(fileStream, Header);
+
+            writer.WriteSignature(Signature);
+            writer.WriteNulls(4);
+            writer.AddString("XNMOffset", XNM);
+            writer.Write(Entries.Count);
+            writer.AddOffset("EntriesOffset");
+
+            // Write the event entries.
+            writer.FillInOffset("EntriesOffset", true);
+            for (int i = 0; i < Entries.Count; i++)
+            {
+                writer.WriteNulls(4);
+                writer.AddString($"TargetNode{i}", Entries[i].TargetNode);
+                writer.AddString($"ParticleBank{i}", Entries[i].ParticleBank);
+                writer.AddString($"Particle{i}", Entries[i].Particle);
+                writer.Write(Entries[i].UnknownVector2_1);
+                writer.WriteNulls(1);
+                writer.Write(Entries[i].UnknownBoolean_1);
+                writer.WriteNulls(2);
+                writer.Write(Entries[i].ParticlePosition);
+                writer.Write(Entries[i].UnknownVector3_2);
+            }
+
+            // Write the footer.
+            writer.FinishWrite(Header);
+        }
+
+        // Clean this Exporter up, lots of bollocks.
+        public void ExportXML(string filepath)
+        {
+            // Root element.
+            XElement rootElem = new XElement("TimeEvent");
+            XAttribute xnmAttr = new XAttribute("XNM", XNM);
+
+            // Event elements.
+            foreach (Entry entry in Entries)
+            {
+                XElement eventElem = new XElement("Event");
+                XElement UnknownString1Elem = new XElement("TargetNode", entry.TargetNode);
+                XAttribute ParticleBankAttr = new XAttribute("ParticleBank", entry.ParticleBank);
+                XElement ParticleElem = new XElement("Particle", entry.Particle);
+                ParticleElem.Add(ParticleBankAttr);
+
+                XElement UnknownVector1Elem = new XElement("UnknownVector2_1");
+                XElement Unknown1XElem = new XElement("X", entry.UnknownVector2_1.X);
+                XElement Unknown1YElem = new XElement("Y", entry.UnknownVector2_1.Y);
+                UnknownVector1Elem.Add(Unknown1XElem, Unknown1YElem);
+
+                XElement UShort1Elem = new XElement("UnknownBoolean_1", entry.UnknownBoolean_1);
+
+                XElement UnknownVector2Elem = new XElement("ParticlePosition");
+                XElement Unknown2XElem = new XElement("X", entry.ParticlePosition.X);
+                XElement Unknown2YElem = new XElement("Y", entry.ParticlePosition.Y);
+                XElement Unknown2ZElem = new XElement("Z", entry.ParticlePosition.Z);
+                UnknownVector2Elem.Add(Unknown2XElem, Unknown2YElem, Unknown2ZElem);
+
+                XElement UnknownVector3Elem = new XElement("UnknownVector3_3");
+                XElement Unknown3XElem = new XElement("X", entry.UnknownVector3_2.X);
+                XElement Unknown3YElem = new XElement("Y", entry.UnknownVector3_2.Y);
+                XElement Unknown3ZElem = new XElement("Z", entry.UnknownVector3_2.Z);
+                UnknownVector3Elem.Add(Unknown3XElem, Unknown3YElem, Unknown3ZElem);
+
+                eventElem.Add(xnmAttr, UnknownString1Elem, ParticleElem, UnknownVector1Elem, UShort1Elem, UnknownVector2Elem, UnknownVector3Elem);
+                rootElem.Add(eventElem);
+            }
+
+            // Save XML.
+            XDocument xml = new XDocument(rootElem);
+            xml.Save(filepath);
+        }
+    }
+}

--- a/Marathon.IO/Formats/Particles/ParticleListContainer.cs
+++ b/Marathon.IO/Formats/Particles/ParticleListContainer.cs
@@ -36,6 +36,7 @@ namespace Marathon.IO.Formats.Particles
     /// </summary>
     public class ParticleListContainer : FileBase
     {
+        public ParticleListContainer() { }
         public ParticleListContainer(string file)
         {
             switch (Path.GetExtension(file))

--- a/Marathon.IO/Formats/Particles/ParticleListContainer.cs
+++ b/Marathon.IO/Formats/Particles/ParticleListContainer.cs
@@ -36,6 +36,19 @@ namespace Marathon.IO.Formats.Particles
     /// </summary>
     public class ParticleListContainer : FileBase
     {
+        public ParticleListContainer(string file)
+        {
+            switch (Path.GetExtension(file))
+            {
+                case ".xml":
+                    ImportXML(file);
+                    break;
+                default:
+                    Load(file);
+                    break;
+            }
+        }
+
         public class Particle
         {
             public string Name1, Name2, FileName; // TODO: not sure what Name2 actually is - sometimes it's the same as Name1, other times it's not, sometimes it's empty.

--- a/Marathon.IO/Formats/Particles/ParticleTextureBank.cs
+++ b/Marathon.IO/Formats/Particles/ParticleTextureBank.cs
@@ -38,6 +38,19 @@ namespace Marathon.IO.Formats.Particles
     /// </summary>
     public class ParticleTextureBank : FileBase
     {
+        public ParticleTextureBank(string file)
+        {
+            switch (Path.GetExtension(file))
+            {
+                case ".xml":
+                    ImportXML(file);
+                    break;
+                default:
+                    Load(file);
+                    break;
+            }
+        }
+
         public class Particle
         {
             public string Name, FileName;
@@ -69,7 +82,7 @@ namespace Marathon.IO.Formats.Particles
             {
                 Particle particle = new Particle()
                 {
-                    Name = new string(reader.ReadChars(32)),
+                    Name     = new string(reader.ReadChars(32)),
                     FileName = new string(reader.ReadChars(128)),
                     Unknown1 = reader.ReadUInt32(),
                     Unknown2 = reader.ReadUInt32()
@@ -142,7 +155,7 @@ namespace Marathon.IO.Formats.Particles
             {
                 Particle particle = new Particle
                 {
-                    Name = particleElem.Element("Name").Value.PadRight(32, '\0'),
+                    Name     = particleElem.Element("Name").Value.PadRight(32, '\0'),
                     FileName = particleElem.Element("FileName").Value.PadRight(128, '\0'),
                     Unknown1 = uint.Parse(particleElem.Element("Unknown1").Value),
                     Unknown2 = uint.Parse(particleElem.Element("Unknown2").Value)

--- a/Marathon.IO/Formats/Particles/ParticleTextureBank.cs
+++ b/Marathon.IO/Formats/Particles/ParticleTextureBank.cs
@@ -38,6 +38,7 @@ namespace Marathon.IO.Formats.Particles
     /// </summary>
     public class ParticleTextureBank : FileBase
     {
+        public ParticleTextureBank() { }
         public ParticleTextureBank(string file)
         {
             switch (Path.GetExtension(file))

--- a/Marathon.IO/Formats/Placement/ObjectPlacement.cs
+++ b/Marathon.IO/Formats/Placement/ObjectPlacement.cs
@@ -41,6 +41,19 @@ namespace Marathon.IO.Formats.Placement
     /// </summary>
     public class ObjectPlacement : FileBase
     {
+        public ObjectPlacement(string file)
+        {
+            switch (Path.GetExtension(file))
+            {
+                case ".xml":
+                    ImportXML(file);
+                    break;
+                default:
+                    Load(file);
+                    break;
+            }
+        }
+
         public class SetObject
         {
             public int ID;             // For convenience when writing XMLs.

--- a/Marathon.IO/Formats/Placement/ObjectPlacement.cs
+++ b/Marathon.IO/Formats/Placement/ObjectPlacement.cs
@@ -41,6 +41,7 @@ namespace Marathon.IO.Formats.Placement
     /// </summary>
     public class ObjectPlacement : FileBase
     {
+        public ObjectPlacement() { }
         public ObjectPlacement(string file)
         {
             switch (Path.GetExtension(file))

--- a/Marathon.IO/Formats/Sounds/SceneBank.cs
+++ b/Marathon.IO/Formats/Sounds/SceneBank.cs
@@ -43,6 +43,19 @@ namespace Marathon.IO.Formats.Sounds
         /* TODO: Experiment with the Unknown values in the Cue entries and see what they do.
                  Also try messing with the Unknown value in the Header and see if it affects anything. */
 
+        public SceneBank(string file)
+        {
+            switch (Path.GetExtension(file))
+            {
+                case ".xml":
+                    ImportXML(file);
+                    break;
+                default:
+                    Load(file);
+                    break;
+            }
+        }
+
         public class Cue
         {
             public string Name;                            // Name of this Cue in the Scene Bank

--- a/Marathon.IO/Formats/Sounds/SceneBank.cs
+++ b/Marathon.IO/Formats/Sounds/SceneBank.cs
@@ -43,6 +43,7 @@ namespace Marathon.IO.Formats.Sounds
         /* TODO: Experiment with the Unknown values in the Cue entries and see what they do.
                  Also try messing with the Unknown value in the Header and see if it affects anything. */
 
+        public SceneBank() { }
         public SceneBank(string file)
         {
             switch (Path.GetExtension(file))

--- a/Marathon.IO/Formats/Text/FontMap.cs
+++ b/Marathon.IO/Formats/Text/FontMap.cs
@@ -36,6 +36,7 @@ namespace Marathon.IO.Formats.Text
     public class FontMap : FileBase
     {
         // TODO: Basically everything, unsure if this reading is finished or not.
+
         public FontMap(string file)
         {
             switch (Path.GetExtension(file))

--- a/Marathon.IO/Formats/Text/FontMap.cs
+++ b/Marathon.IO/Formats/Text/FontMap.cs
@@ -37,6 +37,7 @@ namespace Marathon.IO.Formats.Text
     {
         // TODO: Basically everything, unsure if this reading is finished or not.
 
+        public FontMap() { }
         public FontMap(string file)
         {
             switch (Path.GetExtension(file))

--- a/Marathon.IO/Formats/Text/FontMap.cs
+++ b/Marathon.IO/Formats/Text/FontMap.cs
@@ -35,6 +35,17 @@ namespace Marathon.IO.Formats.Text
     /// </summary>
     public class FontMap : FileBase
     {
+        // TODO: Basically everything, unsure if this reading is finished or not.
+        public FontMap(string file)
+        {
+            switch (Path.GetExtension(file))
+            {
+                default:
+                    Load(file);
+                    break;
+            }
+        }
+
         public class Character
         {
             public byte Unicode,

--- a/Marathon.IO/Formats/Text/FontProportion.cs
+++ b/Marathon.IO/Formats/Text/FontProportion.cs
@@ -35,6 +35,18 @@ namespace Marathon.IO.Formats.Text
     /// </summary>
     public class FontProportion : FileBase
     {
+        // TODO: Basically everything, unsure if this reading is finished or not.
+
+        public FontProportion(string file)
+        {
+            switch (Path.GetExtension(file))
+            {
+                default:
+                    Load(file);
+                    break;
+            }
+        }
+
         public class Character
         {
             public byte Width;

--- a/Marathon.IO/Formats/Text/FontProportion.cs
+++ b/Marathon.IO/Formats/Text/FontProportion.cs
@@ -37,6 +37,7 @@ namespace Marathon.IO.Formats.Text
     {
         // TODO: Basically everything, unsure if this reading is finished or not.
 
+        public FontProportion() { }
         public FontProportion(string file)
         {
             switch (Path.GetExtension(file))

--- a/Marathon.IO/Formats/Text/MessageTable.cs
+++ b/Marathon.IO/Formats/Text/MessageTable.cs
@@ -38,6 +38,7 @@ namespace Marathon.IO.Formats.Text
     /// </summary>
     public class MessageTable : FileBase
     {
+        public MessageTable() { }
         public MessageTable(string file)
         {
             switch (Path.GetExtension(file))

--- a/Marathon.IO/Formats/Text/MessageTable.cs
+++ b/Marathon.IO/Formats/Text/MessageTable.cs
@@ -38,6 +38,19 @@ namespace Marathon.IO.Formats.Text
     /// </summary>
     public class MessageTable : FileBase
     {
+        public MessageTable(string file)
+        {
+            switch (Path.GetExtension(file))
+            {
+                case ".xml":
+                    ImportXML(file);
+                    break;
+                default:
+                    Load(file);
+                    break;
+            }
+        }
+
         public class Message
         {
             public string Name,        // Friendly name pertaining to this message.
@@ -61,7 +74,7 @@ namespace Marathon.IO.Formats.Text
 
             // Store offsets for the string table.
             uint stringTableOffset = reader.ReadUInt32(); // Location of the table of internal string names (including the name) in this file.
-            uint stringCount = reader.ReadUInt32();       // Count of internal string enteries in this file.
+            uint stringCount       = reader.ReadUInt32(); // Count of internal string enteries in this file.
 
             // Get name of MST.
             long namePos = reader.BaseStream.Position;
@@ -74,8 +87,8 @@ namespace Marathon.IO.Formats.Text
                 Message entry = new Message();
 
                 // Store offsets for later.
-                uint nameOffset = reader.ReadUInt32();
-                uint textOffset = reader.ReadUInt32();
+                uint nameOffset        = reader.ReadUInt32();
+                uint textOffset        = reader.ReadUInt32();
                 uint placeholderOffset = reader.ReadUInt32();
 
                 // Stores the current position to jump back to later.
@@ -180,7 +193,7 @@ namespace Marathon.IO.Formats.Text
             {
                 Message entry = new Message
                 {
-                    Name = msgElement.Attribute("Name").Value,
+                    Name        = msgElement.Attribute("Name").Value,
                     Placeholder = msgElement.Attribute("Placeholder").Value,
 
                     // Parse the escaped \f and \n characters.

--- a/Marathon.IO/Formats/Text/PictureFont.cs
+++ b/Marathon.IO/Formats/Text/PictureFont.cs
@@ -37,6 +37,7 @@ namespace Marathon.IO.Formats.Text
     /// </summary>
     public class PictureFont : FileBase
     {
+        public PictureFont() { }
         public PictureFont(string file)
         {
             switch (Path.GetExtension(file))

--- a/Marathon.IO/Formats/Text/PictureFont.cs
+++ b/Marathon.IO/Formats/Text/PictureFont.cs
@@ -37,6 +37,19 @@ namespace Marathon.IO.Formats.Text
     /// </summary>
     public class PictureFont : FileBase
     {
+        public PictureFont(string file)
+        {
+            switch (Path.GetExtension(file))
+            {
+                case ".xml":
+                    ImportXML(file);
+                    break;
+                default:
+                    Load(file);
+                    break;
+            }
+        }
+
         public class SubImage
         {
             public string Placeholder;
@@ -98,7 +111,7 @@ namespace Marathon.IO.Formats.Text
         {
             // Header
             BINAv1Header header = new BINAv1Header();
-            BINAWriter writer = new BINAWriter(stream, header);
+            BINAWriter writer   = new BINAWriter(stream, header);
             writer.WriteSignature(Signature);
 
             // Texture
@@ -127,7 +140,7 @@ namespace Marathon.IO.Formats.Text
             XElement rootElem = new XElement("PFT");
 
             // Texture
-            XElement typeElem = new XElement("Texture");
+            XElement typeElem   = new XElement("Texture");
             XAttribute typeAttr = new XAttribute("File", Texture);
             typeElem.Add(typeAttr);
 

--- a/Marathon.IO/Formats/Textures/DirectDrawMatrix.cs
+++ b/Marathon.IO/Formats/Textures/DirectDrawMatrix.cs
@@ -34,6 +34,20 @@ namespace Marathon.IO.Formats.Textures
     /// </summary>
     public class DirectDrawMatrix : FileBase
     {
+
+        /* TODO: Add writing support - the game never uses this format, so this is very low priority.
+                 Each node has 32-byte alignment, so there are an extra set of nulls at the end of each one. */
+
+        public DirectDrawMatrix(string file)
+        {
+            switch (Path.GetExtension(file))
+            {
+                default:
+                    Load(file);
+                    break;
+            }
+        }
+
         public enum MatrixType
         {
             Root    = 0x204D4444, // DDM 
@@ -124,8 +138,5 @@ namespace Marathon.IO.Formats.Textures
                 Nodes.Add(node);
             }
         }
-
-        /* TODO: Add writing support - the game never uses this format, so this is very low priority.
-                 Each node has 32-byte alignment, so there are an extra set of nulls at the end of each one. */
     }
 }

--- a/Marathon.IO/Formats/Textures/DirectDrawMatrix.cs
+++ b/Marathon.IO/Formats/Textures/DirectDrawMatrix.cs
@@ -38,6 +38,7 @@ namespace Marathon.IO.Formats.Textures
         /* TODO: Add writing support - the game never uses this format, so this is very low priority.
                  Each node has 32-byte alignment, so there are an extra set of nulls at the end of each one. */
 
+        public DirectDrawMatrix() { }
         public DirectDrawMatrix(string file)
         {
             switch (Path.GetExtension(file))

--- a/Marathon.IO/Marathon.IO.csproj
+++ b/Marathon.IO/Marathon.IO.csproj
@@ -15,4 +15,8 @@
     <OutputPath>bin\Debug\</OutputPath>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="AssimpNet" Version="5.0.0-beta1" />
+  </ItemGroup>
+
 </Project>

--- a/Marathon.Tests/Marathon.Tests.csproj
+++ b/Marathon.Tests/Marathon.Tests.csproj
@@ -14,6 +14,8 @@
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -47,8 +49,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.manifest" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="AssimpNet, Version=5.0.0.0, Culture=neutral, PublicKeyToken=0d51b391f59f42a6, processorArchitecture=MSIL">
+      <HintPath>..\packages\AssimpNet.5.0.0-beta1\lib\net40\AssimpNet.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
@@ -58,4 +64,11 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\AssimpNet.5.0.0-beta1\build\AssimpNet.targets" Condition="Exists('..\packages\AssimpNet.5.0.0-beta1\build\AssimpNet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\AssimpNet.5.0.0-beta1\build\AssimpNet.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\AssimpNet.5.0.0-beta1\build\AssimpNet.targets'))" />
+  </Target>
 </Project>

--- a/Marathon.Tests/Program.cs
+++ b/Marathon.Tests/Program.cs
@@ -1,4 +1,11 @@
-﻿namespace Marathon.Tests
+﻿using Marathon.IO.Formats.Meshes;
+using Marathon.IO.Formats.Particles;
+using Marathon.IO.Formats.Placement;
+using Marathon.IO.Formats.Archives;
+using System.IO;
+using System.Collections.Generic;
+
+namespace Marathon.Tests
 {
     /// <summary>
     /// <para>A simple command-line application used for testing APIs.</para>
@@ -8,7 +15,44 @@
     {
         static void Main()
         {
+            string[] x360Arcs = Directory.GetFiles(@"G:\Sonic '06\Game Dump", "*.arc", SearchOption.AllDirectories);
+            string[] ps3Arcs = Directory.GetFiles(@"G:\Sonic '06\PS3 Game Dump", "*.arc", SearchOption.AllDirectories);
+            List<string> filetypes = new List<string>();
+            filetypes.Add(".arc");
 
+            foreach(string arcFile in x360Arcs)
+            {
+                System.Console.WriteLine(arcFile);
+                U8Archive arc = new U8Archive(arcFile);
+                List<IO.Formats.ArchiveFile> files = arc.GetFiles();
+                foreach(IO.Formats.ArchiveFile file in files)
+                {
+                    if (!filetypes.Contains(Path.GetExtension(file.Name)))
+                    {
+                        filetypes.Add(Path.GetExtension(file.Name));
+                    }
+                }
+            }
+
+            foreach (string arcFile in ps3Arcs)
+            {
+                System.Console.WriteLine(arcFile);
+                U8Archive arc = new U8Archive(arcFile);
+                List<IO.Formats.ArchiveFile> files = arc.GetFiles();
+                foreach (IO.Formats.ArchiveFile file in files)
+                {
+                    if (!filetypes.Contains(Path.GetExtension(file.Name)))
+                    {
+                        filetypes.Add(Path.GetExtension(file.Name));
+                    }
+                }
+            }
+
+            filetypes.Sort();
+            foreach(string filetype in filetypes)
+            {
+                System.Console.WriteLine(filetype);
+            }
         }
     }
 }

--- a/Marathon.Tests/packages.config
+++ b/Marathon.Tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="AssimpNet" version="5.0.0-beta1" targetFramework="net48" />
+</packages>


### PR DESCRIPTION
Adding the ability to directly load a file into the formats from the constructor (is that the right term for this?), rather than having to create it then go
`thing.Load(file);`

Also replaces the sloppy OBJ importer for collision with an [Assimp-Net](https://www.nuget.org/packages/AssimpNet/5.0.0-beta1) based solution, might not be the cleanest, but it seems to work quite well?